### PR TITLE
chore(iOS): fix xcode cloud build

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,6 +1,8 @@
 # Uncomment this line to define a global platform for your project
 platform :ios, '15.0'
 
+$FirebaseSDKVersion = '10.2.0'
+
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -25,15 +25,13 @@ flutter pub get
 
 # 4) Install necessary Ruby gems locally (set GEM_HOME to avoid permission issues)
 export GEM_HOME="$HOME/.gem"
+export GEM_PATH="$GEM_HOME:$GEM_PATH"
 export PATH="$GEM_HOME/bin:$PATH"
+gem install --no-document rexml -v 3.3.6
+gem install --no-document xcodeproj -v 1.24.0
 
-# Install gems locally without needing sudo
-gem install rexml -v '>= 3.3.6'
-gem install xcodeproj
-
-# Ensure ffi gem is installed with correct version
-gem install ffi -v '1.17.0'
-
-# 5) CocoaPods install from the correct ios directory
+# 5) CocoaPods
 cd "$REPO_ROOT/ios"
+rm -f Podfile.lock            
+pod repo update
 pod install --repo-update


### PR DESCRIPTION
Maybe it will fix
```
[!] CocoaPods could not find compatible versions for pod "GTMSessionFetcher/Core":

  In snapshot (Podfile.lock):

    GTMSessionFetcher/Core (< 6.0, = 5.0.0, >= 3.4)

  In Podfile:

    google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`) was resolved to 0.0.1, which depends on

      GoogleSignIn (~> 9.0) was resolved to 9.0.0, which depends on

        GTMSessionFetcher/Core (~> 3.3)

You have either:

 * changed the constraints of dependency `GTMSessionFetcher/Core` inside your development pod `google_sign_in_ios`.

   You should run `pod update GTMSessionFetcher/Core` to apply changes you've made.

오류
Command exited with non-zero exit-code: 1
```