### PR TITLE
2025-10-06 베타 배포(3) (v1.1.2 테스트)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -56,6 +56,10 @@
 	<array>
 		<string>google</string>
 		<string>com.google</string>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+		<string>kakaotalk</string>
 	</array>
 	<key>GIDClientID</key>
 	<string>348194173787-lbm02t1gmn4krroo8ehjl0c0a7hh1f0m.apps.googleusercontent.com</string>
@@ -74,13 +78,6 @@
 			<string>kakao5b75899fba79dc8e1651fa8c98ba12f8</string>
 		</array>
 	</dict>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaokompassauth</string>
-		<string>kakaolink</string>
-		<string>kakaoplus</string>
-		<string>kakaotalk</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -75,5 +75,12 @@
 		</array>
 	</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+		<string>kakaotalk</string>
+	</array>
 </dict>
 </plist>

--- a/lib/app/modules/account/controllers/account_view_controller.dart
+++ b/lib/app/modules/account/controllers/account_view_controller.dart
@@ -61,12 +61,10 @@ class AccountViewController extends GetxController {
         content: '로그아웃 하시겠습니까?',
         actionText: '로그아웃',
         action: () async {
-          Get.back();
           await _authService.logout();
           if (Get.isRegistered<NotificationRepository>()) {
             Get.find<NotificationRepository>().clearList();
           }
-          Get.offAndToNamed(Routes.LOGIN);
         },
       ),
     );
@@ -83,7 +81,6 @@ class AccountViewController extends GetxController {
             if (Get.isRegistered<NotificationRepository>()) {
               Get.find<NotificationRepository>().clearList();
             }
-            Get.offAndToNamed(Routes.LOGIN);
           }
         },
       ),

--- a/lib/app/modules/account/controllers/account_view_controller.dart
+++ b/lib/app/modules/account/controllers/account_view_controller.dart
@@ -2,7 +2,6 @@ import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/modules/account/widgets/account_bottom_modal.dart';
 import 'package:duty_it/app/modules/account/widgets/account_dialog.dart';
 import 'package:duty_it/app/modules/notifications/repositories/notification_repository.dart';
-import 'package:duty_it/app/routes/app_pages.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:flutter/material.dart';
 
@@ -62,9 +61,6 @@ class AccountViewController extends GetxController {
         actionText: '로그아웃',
         action: () async {
           await _authService.logout();
-          if (Get.isRegistered<NotificationRepository>()) {
-            Get.find<NotificationRepository>().clearList();
-          }
         },
       ),
     );
@@ -77,11 +73,11 @@ class AccountViewController extends GetxController {
         content: '탈퇴 하시겠습니까?\n이 작업은 복구할 수 없습니다.',
         actionText: '탈퇴',
         action: () async {
-          if (await _authService.withdraw()) {
-            if (Get.isRegistered<NotificationRepository>()) {
-              Get.find<NotificationRepository>().clearList();
-            }
+          if (Get.isRegistered<NotificationRepository>()) {
+            await Get.find<NotificationRepository>().clearList(); // TODO: 회원탈퇴에 실패했지만 알림 목록이 초기화되는 현상이 발생할 수 있음
           }
+
+          await _authService.withdraw();
         },
       ),
     );

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -18,7 +18,7 @@ class HomeView extends GetView<HomeViewController> {
       padding: EdgeInsets.symmetric(horizontal: 16),
       child: RefreshIndicator.adaptive(
         onRefresh: () async {
-          controller.fetchNextPage(clearPage: true);
+          await controller.fetchNextPage(clearPage: true);
         },
         child: CustomScrollView(
           slivers: [

--- a/lib/app/modules/main/controllers/main_view_controller.dart
+++ b/lib/app/modules/main/controllers/main_view_controller.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:duty_it/app/api_client.dart';
+import 'package:duty_it/app/core/utils/app_utils.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -8,6 +12,7 @@ import 'package:duty_it/app/routes/app_pages.dart';
 class MainViewController extends GetxController {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   get scaffoldKey => _scaffoldKey;
+  StreamSubscription? _authListener;
 
   @override
   void onInit() {
@@ -20,6 +25,19 @@ class MainViewController extends GetxController {
 
       return RequestFail(null);
     });
+
+    _authListener = FirebaseAuth.instance.authStateChanges().listen((data) {
+      if (data == null) { // 로그인 상태가 아님
+        Get.offAllNamed(Routes.LOGIN);
+        AppUtils.showSnackBar("로그아웃 되었습니다.");
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _authListener?.cancel();
   }
 
   void openEndDrawer() {

--- a/lib/app/modules/notifications/repositories/notification_repository.dart
+++ b/lib/app/modules/notifications/repositories/notification_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:duty_it/app/modules/notifications/models/fcm_notification.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,18 +10,20 @@ import 'package:synchronized/synchronized.dart';
 class NotificationRepository {
   static const String _prefix = "notifications:";
   static const String _itemKeyPrefix = "${_prefix}noti:";
-  static const String _idListKey = "${_prefix}id_list";
   static const int itemCountLimit = 100;
 
   late final SharedPreferencesAsync sp;
   final Lock _workLock = Lock();
 
+  Future<String> get _uid async => FirebaseAuth.instance.currentUser?.uid ?? "unknown";
+  Future<String> get _idListKey async => "${_prefix}id_list:${await _uid}";
+
   NotificationRepository() {
     sp = SharedPreferencesAsync();
   }
-
+  
   Future<List<String>> getIdList() async {
-    List<String>? list = await sp.getStringList(_idListKey);
+    List<String>? list = await sp.getStringList(await _idListKey);
     if (list == null) return [];
 
     return list;
@@ -32,7 +35,7 @@ class NotificationRepository {
       FcmNotification noti = FcmNotification.fromRemoteMessage(rm);
 
       await sp.setString(
-        _getItemKey(noti.id),
+        await _getItemKey(noti.id),
         json.encode(Map<String, dynamic>.from(noti.toJson())),
       );
 
@@ -51,13 +54,13 @@ class NotificationRepository {
       List<String> idList = await getIdList();
       idList.remove(id);
 
-      await Future.wait([sp.remove(_getItemKey(id)), _saveIdList(idList)]);
+      await Future.wait([sp.remove(await _getItemKey(id)), _saveIdList(idList)]);
     });
   }
 
   Future<void> readNotification(String id) async {
     await _workLock.synchronized(() async {
-      String key = _getItemKey(id);
+      String key = await _getItemKey(id);
       if (!await sp.containsKey(key)) return;
 
       FcmNotification noti = FcmNotification.fromJson(
@@ -84,7 +87,7 @@ class NotificationRepository {
   }
 
   Future<FcmNotification?> getNotificationById(String id) async {
-    String key = _getItemKey(id);
+    String key = await _getItemKey(id);
 
     String? jsonNoti = await sp.getString(key);
 
@@ -104,17 +107,18 @@ class NotificationRepository {
     await _workLock.synchronized(() async {
       var idList = await getIdList();
       await Future.wait(
-        idList.map((e) => sp.remove(_getItemKey(e))).toList()
+        idList.map((e) async => await sp.remove(await _getItemKey(e))).toList()
           ..add(_saveIdList([])),
       );
     });
   }
 
-  String _getItemKey(String id) {
-    return "$_itemKeyPrefix$id";
+  Future<String> _getItemKey(String id) async {
+    String uid = await _uid;
+    return "$_itemKeyPrefix$uid:$id";
   }
 
   Future<void> _saveIdList(List<String> idList) async {
-    await sp.setStringList(_idListKey, idList);
+    await sp.setStringList(await _idListKey, idList);
   }
 }

--- a/lib/app/services/auth/strategies/apple_login_strategy.dart
+++ b/lib/app/services/auth/strategies/apple_login_strategy.dart
@@ -12,8 +12,9 @@ class AppleLoginStrategy extends SocialLoginStrategy {
       final appleProvider = AppleAuthProvider();
       appleProvider.addScope('email');
       appleProvider.addScope('name');
-
-      await FirebaseAuth.instance.signInWithProvider(appleProvider);
+      
+      if (kIsWeb) await FirebaseAuth.instance.signInWithPopup(appleProvider);
+      else await FirebaseAuth.instance.signInWithProvider(appleProvider);
       return SocialLoginSuccess();
     } catch (e, st) {
       FirebaseCrashlytics.instance.recordError(e, st, fatal: false);

--- a/lib/app/services/auth/strategies/google_login_strategy.dart
+++ b/lib/app/services/auth/strategies/google_login_strategy.dart
@@ -40,6 +40,8 @@ class GoogleLoginStrategy extends SocialLoginStrategy {
 
   @override
   Future<void> logout() async {
-    await GoogleSignIn.instance.signOut();
+    GoogleSignIn googleSignIn = GoogleSignIn.instance;
+    await googleSignIn.initialize();
+    await googleSignIn.signOut();
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,8 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
+  <meta name="google-signin-client_id" content="348194173787-eai84avmhep2751qlgii2f813p9kvv0u.apps.googleusercontent.com" />
+
   <title>myapp</title>
   <link rel="manifest" href="manifest.json">
 </head>


### PR DESCRIPTION
- refresh indicator가 로딩 상태를 올바르게 표시하도록 수정
- iOS환경에서 카카오톡 로그인시 카카오톡이 정상적으로 실행되도록 iOS 앱 실행 허용 목록 추가
- 웹에서 Apple 로그인 지원
- 구글 로그인이 실패할 수 있는 문제 해결 (로그인 직전 google-sign-in initialize)
- 로그아웃을 main controller에서 스트림 구독으로 감지하도록 로직 변경
- 알림 목록을 uid로 키값을 달리 하여서 계정 별로 관리 + 로그아웃시 알림 목록 초기화 안 하도록 변경

이 베타 버전은 v1.1.2를 릴리즈 하기 직전 테스트하는 용도입니다.