### PR TITLE
v1.1.2 릴리즈 배포

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <div align="center">
   <a href="https://apps.apple.com/eg/app/id6751395152"><img alt="ios" src="https://img.shields.io/badge/App_Store-0D96F6?style=for-the-badge&logo=app-store&logoColor=white" /></a>
-  <a href="https://play.google.com/store/apps/details?id=com.dutyit.app"><img alt="ios" src="https://playbadges.pavi2410.com/badge/downloads?id=com.dutyit.app" /></a>
+  <a href="https://play.google.com/store/apps/details?id=com.dutyit.app"><img alt="google-play" src="https://playbadges.pavi2410.com/badge/downloads?id=com.dutyit.app" /></a>
   
   간호 행사(학술행사·세미나·교육)를 한 곳에서 모아보고, '참여할 수 있는’ 행사를 개인 캘린더에 추가해보세요.
 </div>

--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@
   <img width="20%" height="20%" alt="ios-1" src="https://github.com/user-attachments/assets/a6094188-c78b-45ad-86da-4cc5f14cef02" />
   <img width="20%" height="20%" alt="ios-2" src="https://github.com/user-attachments/assets/df5c78af-74cb-4f83-8d7a-6ee02d0093ab" />
   <img width="20%" height="20%" alt="ios-3" src="https://github.com/user-attachments/assets/747168ee-5d83-4048-a45c-ef5d4b07db6c" />
-</div>
+</div>  
 
-간호 행사(학술행사·세미나·교육)를 한 곳에서 모아보고, '참여할 수 있는’ 행사를 개인 캘린더에 추가해보세요.
+<div align="center">
+  <a href="https://apps.apple.com/eg/app/id6751395152"><img alt="ios" src="https://img.shields.io/badge/App_Store-0D96F6?style=for-the-badge&logo=app-store&logoColor=white" /></a>
+  <a href="https://play.google.com/store/apps/details?id=com.dutyit.app"><img alt="ios" src="https://playbadges.pavi2410.com/badge/downloads?id=com.dutyit.app" /></a>
+  
+  간호 행사(학술행사·세미나·교육)를 한 곳에서 모아보고, '참여할 수 있는’ 행사를 개인 캘린더에 추가해보세요.
+</div>
 
 ## 프로젝트 의의
 2025년 05월 기준 국내에는 아직 간호 대학생과 간호 업계 종사자를 대상으로 하는 행사 큐레이션 앱이나 서비스가 없거나 매우 열악합니다. 듀잇은 이러한 문제점을 발견하고 시작된 프로젝트입니다.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -56,6 +56,10 @@
 	<array>
 		<string>google</string>
 		<string>com.google</string>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+		<string>kakaotalk</string>
 	</array>
 	<key>GIDClientID</key>
 	<string>348194173787-lbm02t1gmn4krroo8ehjl0c0a7hh1f0m.apps.googleusercontent.com</string>
@@ -74,13 +78,6 @@
 			<string>kakao5b75899fba79dc8e1651fa8c98ba12f8</string>
 		</array>
 	</dict>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaokompassauth</string>
-		<string>kakaolink</string>
-		<string>kakaoplus</string>
-		<string>kakaotalk</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -75,5 +75,12 @@
 		</array>
 	</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+		<string>kakaotalk</string>
+	</array>
 </dict>
 </plist>

--- a/lib/app/models/event.dart
+++ b/lib/app/models/event.dart
@@ -26,7 +26,8 @@ abstract class Event with _$Event {
     DateTime? recruitmentEndAt,
     @Default("") String uri,
     @Default("") String thumbnail,
-    @Default(EventType.ETC) EventType eventType,
+    // ignore: invalid_annotation_target
+    @JsonKey(unknownEnumValue: EventType.ETC) @Default(EventType.ETC) EventType eventType,
     @Default(Host(id: 0)) Host host,
     @Default(false) bool isBookmarked,
   }) = _Event;

--- a/lib/app/models/event.freezed.dart
+++ b/lib/app/models/event.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Event {
 
- int get id; String get title; DateTime? get startAt; DateTime? get endAt; DateTime? get recruitmentStartAt; DateTime? get recruitmentEndAt; String get uri; String get thumbnail; EventType get eventType; Host get host; bool get isBookmarked;
+ int get id; String get title; DateTime? get startAt; DateTime? get endAt; DateTime? get recruitmentStartAt; DateTime? get recruitmentEndAt; String get uri; String get thumbnail;@JsonKey(unknownEnumValue: EventType.ETC) EventType get eventType; Host get host; bool get isBookmarked;
 /// Create a copy of Event
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $EventCopyWith<$Res>  {
   factory $EventCopyWith(Event value, $Res Function(Event) _then) = _$EventCopyWithImpl;
 @useResult
 $Res call({
- int id, String title, DateTime? startAt, DateTime? endAt, DateTime? recruitmentStartAt, DateTime? recruitmentEndAt, String uri, String thumbnail, EventType eventType, Host host, bool isBookmarked
+ int id, String title, DateTime? startAt, DateTime? endAt, DateTime? recruitmentStartAt, DateTime? recruitmentEndAt, String uri, String thumbnail,@JsonKey(unknownEnumValue: EventType.ETC) EventType eventType, Host host, bool isBookmarked
 });
 
 
@@ -172,7 +172,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String title,  DateTime? startAt,  DateTime? endAt,  DateTime? recruitmentStartAt,  DateTime? recruitmentEndAt,  String uri,  String thumbnail,  EventType eventType,  Host host,  bool isBookmarked)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String title,  DateTime? startAt,  DateTime? endAt,  DateTime? recruitmentStartAt,  DateTime? recruitmentEndAt,  String uri,  String thumbnail, @JsonKey(unknownEnumValue: EventType.ETC)  EventType eventType,  Host host,  bool isBookmarked)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Event() when $default != null:
 return $default(_that.id,_that.title,_that.startAt,_that.endAt,_that.recruitmentStartAt,_that.recruitmentEndAt,_that.uri,_that.thumbnail,_that.eventType,_that.host,_that.isBookmarked);case _:
@@ -193,7 +193,7 @@ return $default(_that.id,_that.title,_that.startAt,_that.endAt,_that.recruitment
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String title,  DateTime? startAt,  DateTime? endAt,  DateTime? recruitmentStartAt,  DateTime? recruitmentEndAt,  String uri,  String thumbnail,  EventType eventType,  Host host,  bool isBookmarked)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String title,  DateTime? startAt,  DateTime? endAt,  DateTime? recruitmentStartAt,  DateTime? recruitmentEndAt,  String uri,  String thumbnail, @JsonKey(unknownEnumValue: EventType.ETC)  EventType eventType,  Host host,  bool isBookmarked)  $default,) {final _that = this;
 switch (_that) {
 case _Event():
 return $default(_that.id,_that.title,_that.startAt,_that.endAt,_that.recruitmentStartAt,_that.recruitmentEndAt,_that.uri,_that.thumbnail,_that.eventType,_that.host,_that.isBookmarked);case _:
@@ -213,7 +213,7 @@ return $default(_that.id,_that.title,_that.startAt,_that.endAt,_that.recruitment
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String title,  DateTime? startAt,  DateTime? endAt,  DateTime? recruitmentStartAt,  DateTime? recruitmentEndAt,  String uri,  String thumbnail,  EventType eventType,  Host host,  bool isBookmarked)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String title,  DateTime? startAt,  DateTime? endAt,  DateTime? recruitmentStartAt,  DateTime? recruitmentEndAt,  String uri,  String thumbnail, @JsonKey(unknownEnumValue: EventType.ETC)  EventType eventType,  Host host,  bool isBookmarked)?  $default,) {final _that = this;
 switch (_that) {
 case _Event() when $default != null:
 return $default(_that.id,_that.title,_that.startAt,_that.endAt,_that.recruitmentStartAt,_that.recruitmentEndAt,_that.uri,_that.thumbnail,_that.eventType,_that.host,_that.isBookmarked);case _:
@@ -228,7 +228,7 @@ return $default(_that.id,_that.title,_that.startAt,_that.endAt,_that.recruitment
 @JsonSerializable()
 
 class _Event implements Event {
-  const _Event({required this.id, this.title = "?", this.startAt, this.endAt, this.recruitmentStartAt, this.recruitmentEndAt, this.uri = "", this.thumbnail = "", this.eventType = EventType.ETC, this.host = const Host(id: 0), this.isBookmarked = false});
+  const _Event({required this.id, this.title = "?", this.startAt, this.endAt, this.recruitmentStartAt, this.recruitmentEndAt, this.uri = "", this.thumbnail = "", @JsonKey(unknownEnumValue: EventType.ETC) this.eventType = EventType.ETC, this.host = const Host(id: 0), this.isBookmarked = false});
   factory _Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
 
 @override final  int id;
@@ -239,7 +239,7 @@ class _Event implements Event {
 @override final  DateTime? recruitmentEndAt;
 @override@JsonKey() final  String uri;
 @override@JsonKey() final  String thumbnail;
-@override@JsonKey() final  EventType eventType;
+@override@JsonKey(unknownEnumValue: EventType.ETC) final  EventType eventType;
 @override@JsonKey() final  Host host;
 @override@JsonKey() final  bool isBookmarked;
 
@@ -276,7 +276,7 @@ abstract mixin class _$EventCopyWith<$Res> implements $EventCopyWith<$Res> {
   factory _$EventCopyWith(_Event value, $Res Function(_Event) _then) = __$EventCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String title, DateTime? startAt, DateTime? endAt, DateTime? recruitmentStartAt, DateTime? recruitmentEndAt, String uri, String thumbnail, EventType eventType, Host host, bool isBookmarked
+ int id, String title, DateTime? startAt, DateTime? endAt, DateTime? recruitmentStartAt, DateTime? recruitmentEndAt, String uri, String thumbnail,@JsonKey(unknownEnumValue: EventType.ETC) EventType eventType, Host host, bool isBookmarked
 });
 
 

--- a/lib/app/models/event.g.dart
+++ b/lib/app/models/event.g.dart
@@ -22,7 +22,11 @@ _Event _$EventFromJson(Map<String, dynamic> json) => _Event(
   uri: json['uri'] as String? ?? "",
   thumbnail: json['thumbnail'] as String? ?? "",
   eventType:
-      $enumDecodeNullable(_$EventTypeEnumMap, json['eventType']) ??
+      $enumDecodeNullable(
+        _$EventTypeEnumMap,
+        json['eventType'],
+        unknownValue: EventType.ETC,
+      ) ??
       EventType.ETC,
   host: json['host'] == null
       ? const Host(id: 0)
@@ -50,5 +54,7 @@ const _$EventTypeEnumMap = {
   EventType.WEBINAR: 'WEBINAR',
   EventType.WORKSHOP: 'WORKSHOP',
   EventType.CONTEST: 'CONTEST',
+  EventType.CONTINUING_EDUCATION: 'CONTINUING_EDUCATION',
+  EventType.EDUCATION: 'EDUCATION',
   EventType.ETC: 'ETC',
 };

--- a/lib/app/models/event_type.dart
+++ b/lib/app/models/event_type.dart
@@ -6,6 +6,7 @@ enum EventType {
   WEBINAR('웨비나'),
   WORKSHOP('워크숍'),
   CONTEST('콘테스트'),
+  CONTINUING_EDUCATION("보수교육"),
   ETC('기타');
    
   final String displayName;

--- a/lib/app/models/event_type.dart
+++ b/lib/app/models/event_type.dart
@@ -7,6 +7,7 @@ enum EventType {
   WORKSHOP('워크숍'),
   CONTEST('콘테스트'),
   CONTINUING_EDUCATION("보수교육"),
+  EDUCATION("교육"),
   ETC('기타');
    
   final String displayName;

--- a/lib/app/modules/account/controllers/account_view_controller.dart
+++ b/lib/app/modules/account/controllers/account_view_controller.dart
@@ -61,12 +61,10 @@ class AccountViewController extends GetxController {
         content: '로그아웃 하시겠습니까?',
         actionText: '로그아웃',
         action: () async {
-          Get.back();
           await _authService.logout();
           if (Get.isRegistered<NotificationRepository>()) {
             Get.find<NotificationRepository>().clearList();
           }
-          Get.offAndToNamed(Routes.LOGIN);
         },
       ),
     );
@@ -83,7 +81,6 @@ class AccountViewController extends GetxController {
             if (Get.isRegistered<NotificationRepository>()) {
               Get.find<NotificationRepository>().clearList();
             }
-            Get.offAndToNamed(Routes.LOGIN);
           }
         },
       ),

--- a/lib/app/modules/account/controllers/account_view_controller.dart
+++ b/lib/app/modules/account/controllers/account_view_controller.dart
@@ -2,7 +2,6 @@ import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/modules/account/widgets/account_bottom_modal.dart';
 import 'package:duty_it/app/modules/account/widgets/account_dialog.dart';
 import 'package:duty_it/app/modules/notifications/repositories/notification_repository.dart';
-import 'package:duty_it/app/routes/app_pages.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:flutter/material.dart';
 
@@ -62,9 +61,6 @@ class AccountViewController extends GetxController {
         actionText: '로그아웃',
         action: () async {
           await _authService.logout();
-          if (Get.isRegistered<NotificationRepository>()) {
-            Get.find<NotificationRepository>().clearList();
-          }
         },
       ),
     );
@@ -77,11 +73,11 @@ class AccountViewController extends GetxController {
         content: '탈퇴 하시겠습니까?\n이 작업은 복구할 수 없습니다.',
         actionText: '탈퇴',
         action: () async {
-          if (await _authService.withdraw()) {
-            if (Get.isRegistered<NotificationRepository>()) {
-              Get.find<NotificationRepository>().clearList();
-            }
+          if (Get.isRegistered<NotificationRepository>()) {
+            await Get.find<NotificationRepository>().clearList(); // TODO: 회원탈퇴에 실패했지만 알림 목록이 초기화되는 현상이 발생할 수 있음
           }
+
+          await _authService.withdraw();
         },
       ),
     );

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -42,6 +42,7 @@ class HomeView extends GetView<HomeViewController> {
               fetchNextPage: controller.fetchNextPage,
               builderDelegate: PagedChildBuilderDelegate<EventCard>(
                 itemBuilder: (context, item, index) => item,
+                newPageProgressIndicatorBuilder: (_) => CircularProgressIndicator.adaptive(),
                 noItemsFoundIndicatorBuilder: (_) {
                   HomeTab tab = controller.selectedTab;
                   if (tab == HomeTab.bookmark) {

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -43,6 +43,8 @@ class HomeView extends GetView<HomeViewController> {
               builderDelegate: PagedChildBuilderDelegate<EventCard>(
                 itemBuilder: (context, item, index) => item,
                 newPageProgressIndicatorBuilder: (_) => CircularProgressIndicator.adaptive(),
+                animateTransitions: true,
+                transitionDuration: Duration(milliseconds: 200),
                 noItemsFoundIndicatorBuilder: (_) {
                   HomeTab tab = controller.selectedTab;
                   if (tab == HomeTab.bookmark) {

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -54,7 +54,7 @@ class HomeView extends GetView<HomeViewController> {
                     ),
                   ),
                   animateTransitions: true,
-                  transitionDuration: Duration(milliseconds: 200),
+                  transitionDuration: Duration(milliseconds: 100),
                   noItemsFoundIndicatorBuilder: (_) {
                     HomeTab tab = controller.selectedTab;
                     if (tab == HomeTab.bookmark) {

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -5,7 +5,6 @@ import 'package:duty_it/app/modules/home/widgets/home_header.dart';
 import 'package:duty_it/app/modules/home/widgets/no_bookmarked_item_indicator.dart';
 import 'package:duty_it/app/modules/home/widgets/no_search_item_indicator.dart';
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:persistent_header_adaptive/persistent_header_adaptive.dart';
@@ -17,46 +16,58 @@ class HomeView extends GetView<HomeViewController> {
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 16),
-      child: CustomScrollView(
-        slivers: [
-          SliverAppBar(
-            backgroundColor: Colors.white,
-            surfaceTintColor: Colors.white,
-            elevation: 0,
-            floating: true,
-            snap: true,
-            automaticallyImplyLeading: false,
-            actions: <Widget>[Container()],
-            leading: SizedBox.shrink(),
-            flexibleSpace: FlexibleSpaceBar(background: HomeAppBar()),
-          ),
+      child: RefreshIndicator.adaptive(
+        onRefresh: () async {
+          controller.fetchNextPage(clearPage: true);
+        },
+        child: CustomScrollView(
+          slivers: [
+            SliverAppBar(
+              backgroundColor: Colors.white,
+              surfaceTintColor: Colors.white,
+              elevation: 0,
+              floating: true,
+              snap: true,
+              automaticallyImplyLeading: false,
+              actions: <Widget>[Container()],
+              leading: SizedBox.shrink(),
+              flexibleSpace: FlexibleSpaceBar(background: HomeAppBar()),
+            ),
 
-          AdaptiveHeightSliverPersistentHeader(
-            pinned: true,
-            child: HomeHeader(controller: controller),
-          ),
+            AdaptiveHeightSliverPersistentHeader(
+              pinned: true,
+              child: HomeHeader(controller: controller),
+            ),
 
-          Obx(() {
-            return PagedSliverList<int, EventCard>(
-              state: controller.pagingState,
-              fetchNextPage: controller.fetchNextPage,
-              builderDelegate: PagedChildBuilderDelegate<EventCard>(
-                itemBuilder: (context, item, index) => item,
-                newPageProgressIndicatorBuilder: (_) => CircularProgressIndicator.adaptive(),
-                animateTransitions: true,
-                transitionDuration: Duration(milliseconds: 200),
-                noItemsFoundIndicatorBuilder: (_) {
-                  HomeTab tab = controller.selectedTab;
-                  if (tab == HomeTab.bookmark) {
-                    return NoBookmarkedItemIndicator();
-                  }
+            Obx(() {
+              return PagedSliverList<int, EventCard>(
+                state: controller.pagingState,
+                fetchNextPage: controller.fetchNextPage,
+                builderDelegate: PagedChildBuilderDelegate<EventCard>(
+                  itemBuilder: (context, item, index) => item,
+                  newPageProgressIndicatorBuilder: (_) => Align(
+                    alignment: Alignment.center,
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator.adaptive(),
+                    ),
+                  ),
+                  animateTransitions: true,
+                  transitionDuration: Duration(milliseconds: 200),
+                  noItemsFoundIndicatorBuilder: (_) {
+                    HomeTab tab = controller.selectedTab;
+                    if (tab == HomeTab.bookmark) {
+                      return NoBookmarkedItemIndicator();
+                    }
 
-                  return NoSearchItemIndicator();
-                },
-              ),
-            );
-          }),
-        ],
+                    return NoSearchItemIndicator();
+                  },
+                ),
+              );
+            }),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -18,7 +18,7 @@ class HomeView extends GetView<HomeViewController> {
       padding: EdgeInsets.symmetric(horizontal: 16),
       child: RefreshIndicator.adaptive(
         onRefresh: () async {
-          controller.fetchNextPage(clearPage: true);
+          await controller.fetchNextPage(clearPage: true);
         },
         child: CustomScrollView(
           slivers: [

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -238,16 +238,51 @@ class _EventCardMetaSection extends StatelessWidget {
         SizedBox(height: 4),
         _EventMetaItem(
           name: "일시",
-          value:
-              "${AppUtils.formatDateTime(event.startAt ?? DateTime.now())} ~ ${AppUtils.formatDateTime(event.endAt ?? DateTime.now())}",
+          value: _formatPeriod(event.startAt, event.endAt),
         ),
-        SizedBox(height: 4),
-        _EventMetaItem(
-          name: "모집",
-          value:
-              "${AppUtils.formatDateTime(event.recruitmentStartAt ?? DateTime.now())} ~ ${AppUtils.formatDateTime(event.recruitmentEndAt ?? DateTime.now())}",
+        Visibility(
+          visible:
+              !(event.recruitmentStartAt == null &&
+                  event.recruitmentEndAt == null),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(height: 4),
+              _EventMetaItem(
+                name: "모집",
+                value: _formatPeriod(
+                  event.recruitmentStartAt,
+                  event.recruitmentEndAt,
+                ),
+              ),
+            ],
+          ),
         ),
       ],
     );
+  }
+
+  String _formatPeriod(DateTime? start, DateTime? end) {
+    String? startStr = start != null ? AppUtils.formatDateTime(start) : null;
+    String? endStr = end != null ? AppUtils.formatDateTime(end) : null;
+
+    String ret;
+
+    if (start != null && end != null) {
+      if (startStr == endStr) {
+        ret = "$startStr";
+      } else {
+        ret = "$startStr ~ $endStr";
+      }
+    } else if (start == null && end == null) {
+      ret = "정보 없음";
+    } else if (start != null) {
+      ret = "$startStr";
+    } else {
+      // Only end date
+      ret = " ~ $endStr";
+    }
+
+    return ret;
   }
 }

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -122,7 +122,7 @@ class _EventCardImageSection extends StatelessWidget {
                   ),
                   image: DecorationImage(
                     image: imageProvider,
-                    fit: BoxFit.cover,
+                    fit: BoxFit.fitWidth,
                     alignment: Alignment.center,
                   ),
                 ),

--- a/lib/app/modules/home/widgets/modal/sorting_bottom_modal.dart
+++ b/lib/app/modules/home/widgets/modal/sorting_bottom_modal.dart
@@ -89,7 +89,7 @@ class SortingBottomModal extends StatelessWidget {
             text: '정렬 적용',
             onTap: () => controller.applyAndClose(),
           ),
-          SizedBox(height: 16),
+          SizedBox(height: 24),
         ],
       ),
     );

--- a/lib/app/modules/main/controllers/main_view_controller.dart
+++ b/lib/app/modules/main/controllers/main_view_controller.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:duty_it/app/api_client.dart';
+import 'package:duty_it/app/core/utils/app_utils.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -8,6 +12,7 @@ import 'package:duty_it/app/routes/app_pages.dart';
 class MainViewController extends GetxController {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   get scaffoldKey => _scaffoldKey;
+  StreamSubscription? _authListener;
 
   @override
   void onInit() {
@@ -20,6 +25,19 @@ class MainViewController extends GetxController {
 
       return RequestFail(null);
     });
+
+    _authListener = FirebaseAuth.instance.authStateChanges().listen((data) {
+      if (data == null) { // 로그인 상태가 아님
+        Get.offAllNamed(Routes.LOGIN);
+        AppUtils.showSnackBar("로그아웃 되었습니다.");
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _authListener?.cancel();
   }
 
   void openEndDrawer() {

--- a/lib/app/modules/notifications/repositories/notification_repository.dart
+++ b/lib/app/modules/notifications/repositories/notification_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:duty_it/app/modules/notifications/models/fcm_notification.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,18 +10,20 @@ import 'package:synchronized/synchronized.dart';
 class NotificationRepository {
   static const String _prefix = "notifications:";
   static const String _itemKeyPrefix = "${_prefix}noti:";
-  static const String _idListKey = "${_prefix}id_list";
   static const int itemCountLimit = 100;
 
   late final SharedPreferencesAsync sp;
   final Lock _workLock = Lock();
 
+  Future<String> get _uid async => FirebaseAuth.instance.currentUser?.uid ?? "unknown";
+  Future<String> get _idListKey async => "${_prefix}id_list:${await _uid}";
+
   NotificationRepository() {
     sp = SharedPreferencesAsync();
   }
-
+  
   Future<List<String>> getIdList() async {
-    List<String>? list = await sp.getStringList(_idListKey);
+    List<String>? list = await sp.getStringList(await _idListKey);
     if (list == null) return [];
 
     return list;
@@ -32,7 +35,7 @@ class NotificationRepository {
       FcmNotification noti = FcmNotification.fromRemoteMessage(rm);
 
       await sp.setString(
-        _getItemKey(noti.id),
+        await _getItemKey(noti.id),
         json.encode(Map<String, dynamic>.from(noti.toJson())),
       );
 
@@ -51,13 +54,13 @@ class NotificationRepository {
       List<String> idList = await getIdList();
       idList.remove(id);
 
-      await Future.wait([sp.remove(_getItemKey(id)), _saveIdList(idList)]);
+      await Future.wait([sp.remove(await _getItemKey(id)), _saveIdList(idList)]);
     });
   }
 
   Future<void> readNotification(String id) async {
     await _workLock.synchronized(() async {
-      String key = _getItemKey(id);
+      String key = await _getItemKey(id);
       if (!await sp.containsKey(key)) return;
 
       FcmNotification noti = FcmNotification.fromJson(
@@ -84,7 +87,7 @@ class NotificationRepository {
   }
 
   Future<FcmNotification?> getNotificationById(String id) async {
-    String key = _getItemKey(id);
+    String key = await _getItemKey(id);
 
     String? jsonNoti = await sp.getString(key);
 
@@ -104,17 +107,18 @@ class NotificationRepository {
     await _workLock.synchronized(() async {
       var idList = await getIdList();
       await Future.wait(
-        idList.map((e) => sp.remove(_getItemKey(e))).toList()
+        idList.map((e) async => await sp.remove(await _getItemKey(e))).toList()
           ..add(_saveIdList([])),
       );
     });
   }
 
-  String _getItemKey(String id) {
-    return "$_itemKeyPrefix$id";
+  Future<String> _getItemKey(String id) async {
+    String uid = await _uid;
+    return "$_itemKeyPrefix$uid:$id";
   }
 
   Future<void> _saveIdList(List<String> idList) async {
-    await sp.setStringList(_idListKey, idList);
+    await sp.setStringList(await _idListKey, idList);
   }
 }

--- a/lib/app/services/app_settings_service.dart
+++ b/lib/app/services/app_settings_service.dart
@@ -36,7 +36,7 @@ class AppSettingsService extends GetxService {
   void onInit() async {
     super.onInit();
 
-    eventSortingTypeSetting = AppSetting(key: 'event_sorting_type', box: _box, defaultValue: EventSortingType.latest.name);
+    eventSortingTypeSetting = AppSetting(key: 'event_sorting_type', box: _box, defaultValue: EventSortingType.eventStartSoon.name);
     dontShowAutoAddModal = AppSetting(key: 'dont_show_auto_add_modal', box: _box, defaultValue: false);
   }
 

--- a/lib/app/services/auth/strategies/apple_login_strategy.dart
+++ b/lib/app/services/auth/strategies/apple_login_strategy.dart
@@ -12,8 +12,9 @@ class AppleLoginStrategy extends SocialLoginStrategy {
       final appleProvider = AppleAuthProvider();
       appleProvider.addScope('email');
       appleProvider.addScope('name');
-
-      await FirebaseAuth.instance.signInWithProvider(appleProvider);
+      
+      if (kIsWeb) await FirebaseAuth.instance.signInWithPopup(appleProvider);
+      else await FirebaseAuth.instance.signInWithProvider(appleProvider);
       return SocialLoginSuccess();
     } catch (e, st) {
       FirebaseCrashlytics.instance.recordError(e, st, fatal: false);

--- a/lib/app/services/auth/strategies/google_login_strategy.dart
+++ b/lib/app/services/auth/strategies/google_login_strategy.dart
@@ -40,6 +40,8 @@ class GoogleLoginStrategy extends SocialLoginStrategy {
 
   @override
   Future<void> logout() async {
-    await GoogleSignIn.instance.signOut();
+    GoogleSignIn googleSignIn = GoogleSignIn.instance;
+    await googleSignIn.initialize();
+    await googleSignIn.signOut();
   }
 }

--- a/lib/app/services/auth/strategies/kakao_login_strategy.dart
+++ b/lib/app/services/auth/strategies/kakao_login_strategy.dart
@@ -1,35 +1,109 @@
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:duty_it/app/core/utils/app_utils.dart';
 import 'package:duty_it/app/services/auth/models/social_login_result.dart';
 import 'package:duty_it/app/services/auth/strategies/social_login_strategy.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
-import 'package:kakao_flutter_sdk/kakao_flutter_sdk_user.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk_user.dart' hide User;
 
 class KakaoLoginStrategy extends SocialLoginStrategy {
   @override
   Future<SocialLoginResult> login() async {
     try {
-      bool installed = await isKakaoTalkInstalled();
-      OAuthToken authToken = await (installed
+      final installed = await isKakaoTalkInstalled();
+      final OAuthToken authToken = await (installed
           ? UserApi.instance.loginWithKakaoTalk()
           : UserApi.instance.loginWithKakaoAccount());
 
-      var provider = kIsWeb ? OAuthProvider('oidc.kakao_web') : OAuthProvider('oidc.kakao');
-      var credential = provider.credential(
-        idToken: authToken.idToken,
-        accessToken: authToken.accessToken,
-      );
+      final callable = FirebaseFunctions.instance.httpsCallable('kakaoSignIn');
+      final rp = await callable.call(<String, dynamic>{
+        'accessToken': authToken.accessToken,
+      });
+      final data = rp.data as Map;
+      final customToken = data['customToken'] as String?;
 
-      await FirebaseAuth.instance.signInWithCredential(credential);
+      if (customToken == null) {
+        return SocialLoginFail(reason: kDebugMode ? "customToken이 null임" : '로그인 실패 : 인증 정보가 없습니다.');
+      }
+
+      final credential = await FirebaseAuth.instance.signInWithCustomToken(customToken);
+      final user = credential.user;
+      if (user == null) {
+        return SocialLoginFail(reason: '로그인 실패 : 사용자 정보가 없습니다.');
+      }
+
+      try {
+        await linkKakaoOidcWithTokens(user, authToken);
+      } on FirebaseAuthException catch (_) {
+        if (kIsWeb) {
+          await linkKakaoOidcViaPopup(user);
+        } else {
+          await linkKakaoOidcViaRedirect(user);
+        }
+      }
+
       return SocialLoginSuccess();
     } catch (e, s) {
       FirebaseCrashlytics.instance.recordError(e, s, fatal: false);
       if (kDebugMode) AppUtils.showSnackBar("$e");
-      if (kDebugMode) AppUtils.showSnackBar("$s");
       return SocialLoginFail(reason: kDebugMode ? e.toString() : '로그인 실패');
     }
   }
+
+  Future<void> linkKakaoOidcWithTokens(User user, OAuthToken kakaoToken) async {
+  final provider = OAuthProvider('oidc.kakao_rest');
+
+  final hasIdToken = (kakaoToken.idToken?.isNotEmpty ?? false);
+
+  final credential = provider.credential(
+    accessToken: kakaoToken.accessToken,
+    idToken: hasIdToken ? kakaoToken.idToken : null,
+  );
+
+  final alreadyLinked = user.providerData.any((p) => p.providerId == 'oidc.kakao_rest');
+  if (alreadyLinked) return;
+
+  try {
+    await user.linkWithCredential(credential);
+  } on FirebaseAuthException catch (e) {
+    if (e.code == 'provider-already-linked') return;
+    if (e.code == 'credential-already-in-use') {
+      rethrow;
+    }
+    if (e.code == 'requires-recent-login') {
+      await user.reauthenticateWithCredential(credential);
+      await user.linkWithCredential(credential);
+    } else {
+      rethrow;
+    }
+  }
+}
+
+Future<void> linkKakaoOidcViaPopup(User user) async {
+  final provider = OAuthProvider('oidc.kakao_rest');
+  if (!kIsWeb) throw UnsupportedError('Web only');
+
+  try {
+    await user.linkWithPopup(provider);
+  } on FirebaseAuthException catch (e) {
+    if (e.code == 'popup-closed-by-user') return;
+    if (e.code == 'provider-already-linked') return;
+    rethrow;
+  }
+}
+
+Future<void> linkKakaoOidcViaRedirect(User user) async {
+  final provider = OAuthProvider('oidc.kakao_rest');
+  provider.setCustomParameters({
+    'prompt': 'consent',
+  });
+  provider.addScope('openid');
+  provider.addScope('profile');
+  provider.addScope('account_email');
+
+  await user.linkWithProvider(provider);
+}
 
   @override
   Future<void> logout() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  cloud_functions:
+    dependency: "direct main"
+    description:
+      name: cloud_functions
+      sha256: bf3b5b18b794123d452196e407e5952b4fe002043a373f0acac0f8fc6998567f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
+  cloud_functions_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_functions_platform_interface
+      sha256: d3a24cb9bf0a0fe8abe71db47d703d368a175d956c40730f7a216211ccbc5d8d
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.5"
+  cloud_functions_web:
+    dependency: transitive
+    description:
+      name: cloud_functions_web
+      sha256: dbcde017570afd7186addf8ba7b985a89ddcaf689e76741540d41e7cd0ce5bbe
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   code_builder:
     dependency: transitive
     description:
@@ -349,26 +373,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "967dae9a65f69377beb9f4ab292ea63ce5befa1ce24682cab1b69ca4b7a46927"
+      sha256: "4dd96f05015c0dcceaa47711394c32971aee70169625d5e2477e7676c01ce0ee"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "5dbc900677dcbe5873d22ad7fbd64b047750124f1f9b7ebe2a33b9ddccc838eb"
+      sha256: "5873a370f0d232918e23a5a6137dbe4c2c47cf017301f4ea02d9d636e52f60f0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: f7ee08febc1c4451588ce58ffcf28edaee857e9a196fee88b85deb889990094a
+      sha256: "61a51037312dac781f713308903bb7a1762a7f92f7bc286a3a0947fb2a713b82"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   firebase_crashlytics:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   synchronized: ^3.4.0
   shared_preferences: ^2.5.3
   scroll_snap_list: ^0.9.1
+  cloud_functions: ^6.0.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+1
+version: 1.1.2+1
 
 environment:
   sdk: ^3.8.0-278.1.beta

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,8 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
+  <meta name="google-signin-client_id" content="348194173787-eai84avmhep2751qlgii2f813p9kvv0u.apps.googleusercontent.com" />
+
   <title>myapp</title>
   <link rel="manifest" href="manifest.json">
 </head>


### PR DESCRIPTION
- 이벤트 이미지를 폭(width)에 맞추어 표시합니다. 기관 로고가 더 올바르게 표시됩니다.
- 행사 정렬 기본값은 날짜 임박순으로 변경되었습니다.
- 정렬 모달 하단에 여백을 추가하였습니다.
- 행사 날짜와 모집 날짜 값 존재 여부에 따른 표시 방법을 달리 하였습니다.
- 홈 이벤트 목록 로딩 위젯을 adaptive로 변경하였습니다.
- 홈 이벤트 목록을 당겨서 새로고침할 수 있도록 기능을 추가하였습니다.
- 홈 이벤트 목록 전환 애니메이션이 추가되었습니다.
- 보수교육, 교육이 행사 종류에 추가되었습니다.
- 알려지지 않은 행사 유형이 들어왔을 때 오류가 발생하는 이슈를 해결하였습니다.
- 웹/앱에서 동일한 providerId를 가지도록 oidc.kakao_rest에 link하도록 하였습니다.
- refresh indicator가 로딩 상태를 올바르게 표시하도록 수정
- iOS환경에서 카카오톡 로그인시 카카오톡이 정상적으로 실행되도록 iOS 앱 실행 허용 목록 추가
- 웹에서 Apple 로그인 지원
- 구글 로그인이 실패할 수 있는 문제 해결 (로그인 직전 google-sign-in initialize)
- 로그아웃을 main controller에서 스트림 구독으로 감지하도록 로직 변경
- 알림 목록을 uid로 키값을 달리 하여서 계정 별로 관리 + 로그아웃시 알림 목록 초기화 안 하도록 변경