### PR TITLE
2025-11-08 베타 배포

### DIFF
--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -145,8 +145,8 @@ class HomeViewController extends GetxController with WidgetsBindingObserver {
       pagingState = pagingState.copyWith(
         isLoading: true,
         error: null,
-        keys: clearPage ? [] : const Omit(),
-        pages: clearPage ? [] : const Omit(),
+        keys: clearPage ? null : const Omit(),
+        pages: clearPage ? null : const Omit(),
       );
 
       // find next key

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -45,6 +45,8 @@ class HomeView extends GetView<HomeViewController> {
                 fetchNextPage: controller.fetchNextPage,
                 builderDelegate: PagedChildBuilderDelegate<EventCard>(
                   itemBuilder: (context, item, index) => item,
+                  firstPageProgressIndicatorBuilder: (_) =>
+                          Center(child: CircularProgressIndicator.adaptive()),
                   newPageProgressIndicatorBuilder: (_) => Align(
                     alignment: Alignment.center,
                     child: SizedBox(

--- a/lib/app/modules/notifications/views/notifications_view.dart
+++ b/lib/app/modules/notifications/views/notifications_view.dart
@@ -34,6 +34,16 @@ class NotificationsView extends GetView<NotificationsViewController> {
                           ),
                         ),
                       ),
+                      firstPageProgressIndicatorBuilder: (_) =>
+                          Center(child: CircularProgressIndicator.adaptive()),
+                      newPageProgressIndicatorBuilder: (_) => Align(
+                        alignment: Alignment.center,
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator.adaptive(),
+                        ),
+                      ),
                     ),
                   );
                 }),

--- a/lib/app/services/auth/strategies/apple_login_strategy.dart
+++ b/lib/app/services/auth/strategies/apple_login_strategy.dart
@@ -24,7 +24,7 @@ class AppleLoginStrategy extends SocialLoginStrategy {
     } catch (e, st) {
       if (e is FirebaseAuthException &&
           (e.code == 'popup-closed-by-user' ||
-              e.code == 'web-context-canceled')) { // 사용자 로그인 취소
+              e.code.toLowerCase().contains('canceled'))) { // 사용자 로그인 취소
         FirebaseAnalytics.instance.logEvent(name: 'login_cancelled', parameters: {'provider': 'apple'});
         return SocialLoginFail(reason: "로그인 취소됨");
       }


### PR DESCRIPTION
# 작업 내용
- 알림 페이지 로딩시 로딩 indicator 위젯을 추가하였습니다.
- 행사 목록 첫 페이지 로딩 위젯을 ``CircularProgressIndicator.adaptive``로 지정하였습니다.
- 행사 목록 초기화시 pagingState의 keys와 pages를 null로 설정하도록 수정하였습니다.
- 애플 로그인 취소 감지 로직을 ``e.code.toLowerCase().contains('canceled')``으로 변경하여 더 유연하게 처리되도록 변경하였습니다.
