### PR TITLE
2025-11-10 베타 배포

### DIFF
--- a/lib/app/modules/search_filter/widgets/host_selection_bottom_modal.dart
+++ b/lib/app/modules/search_filter/widgets/host_selection_bottom_modal.dart
@@ -124,13 +124,16 @@ class _SearchFilterHostSelectionBottomModal
               ),
 
               SizedBox(height: 24),
-              Text(
-                '검색 결과',
-                style: TextStyle(
-                  color: AppColors.black,
-                  fontSize: 15,
-                  fontWeight: FontWeight.w700,
-                  height: 1.20,
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  '검색 결과',
+                  style: TextStyle(
+                    color: AppColors.black,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    height: 1.20,
+                  ),
                 ),
               ),
 

--- a/lib/app/services/app_settings_service.dart
+++ b/lib/app/services/app_settings_service.dart
@@ -14,7 +14,7 @@ class AppSettingsService extends GetxService {
   void onInit() async {
     super.onInit();
 
-    eventSortingTypeSetting = AppSetting(key: 'event_sorting_type', box: _box, defaultValue: EventSortingType.eventStartSoon.name);
+    eventSortingTypeSetting = AppSetting(key: 'event_sorting_type', box: _box, defaultValue: EventSortingType.latest.name);
     dontShowAutoAddModal = AppSetting(key: 'dont_show_auto_add_modal', box: _box, defaultValue: false);
   }
 


### PR DESCRIPTION
# 작업 내용
- 기본 행사 정렬 방식을 다시 '최신 등록순'으로 변경합니다.
- 주최 검색 모달에서 '검색 결과' 텍스트가 좌측에 있도록 수정했습니다.