### PR TITLE
2025-12-11 베타 배포

### DIFF
--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -161,13 +161,14 @@ class ApiClient extends GetConnect {
   /// 알람 목록 조회 (alarms)
   Future<RequestResult<List<AppNotification>>> getNotificationList(
     int page,
+    {int size = 10}
   ) async {
     return await _send(
       () async => await get(
         '/v1/alarms',
         query: {
           'page': "$page",
-          'size': '10',
+          'size': '$size',
           'sortDirection': 'DESC',
           'field': 'ID',
         },
@@ -191,7 +192,7 @@ class ApiClient extends GetConnect {
   /// 알람 모두 읽음 처리 (/alarms/read-all)
   Future<RequestResult<bool>> readAllNotification() async {
     return await _send(
-      () async => await patch('/v1/alarms/read-all', {}),
+      () async => await patch('/v1/alarms/read-all', null),
       map: (rp) {
         if (rp.statusCode == HttpStatus.noContent) return true;
         return false;

--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -298,9 +298,9 @@ class ApiClient extends GetConnect {
     );
   }
 
-  /// 회원탈퇴 (/users/{userId}) - DELETE
-  Future<RequestResult<void>> withdrawUser(int userId) async {
-    return _send(() async => await delete('/users/$userId'), map: (_) => true);
+  /// 회원탈퇴 (/users) - DELETE
+  Future<RequestResult<void>> withdrawUser() async {
+    return _send(() async => await delete('/users'), map: (_) => true);
   }
 
   /// 알림 - 사용자 기기 등록 (/users/device/{token}) - PATCH

--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:duty_it/app/core/models/events_response.dart';
 import 'package:duty_it/app/modules/settings/models/alarm_settings.dart';
 import 'package:duty_it/app/modules/notifications/models/app_notification.dart';
 import 'package:duty_it/app/core/models/app_user.dart';
@@ -34,7 +35,7 @@ class ApiClient extends GetConnect {
 
     httpClient.addRequestModifier<void>((request) async {
       final path = request.url.path;
-      final isAuthPath = path.contains('/auth/');
+      final isAuthPath = path.contains('/v1/auth/');
       if (isAuthPath) return request;
 
       await _loginFuture;
@@ -47,7 +48,7 @@ class ApiClient extends GetConnect {
 
     httpClient.addAuthenticator<void>((request) async {
       final path = request.url.path;
-      if (path.contains('/auth/')) return request;
+      if (path.contains('/v1/auth/')) return request;
 
       await loginAndRefreshToken();
       if (_token == null || _token!.isEmpty) return request;
@@ -156,14 +157,14 @@ class ApiClient extends GetConnect {
   }
 
   // ---------- Alarm ----------
-  
+
   /// 알람 목록 조회 (alarms)
   Future<RequestResult<List<AppNotification>>> getNotificationList(
     int page,
   ) async {
     return await _send(
       () async => await get(
-        '/alarms',
+        '/v1/alarms',
         query: {
           'page': "$page",
           'size': '10',
@@ -190,9 +191,7 @@ class ApiClient extends GetConnect {
   /// 알람 모두 읽음 처리 (/alarms/read-all)
   Future<RequestResult<bool>> readAllNotification() async {
     return await _send(
-      () async => await patch(
-        '/alarms/read-all', {}
-      ),
+      () async => await patch('/v1/alarms/read-all', {}),
       map: (rp) {
         if (rp.statusCode == HttpStatus.noContent) return true;
         return false;
@@ -200,13 +199,10 @@ class ApiClient extends GetConnect {
     );
   }
 
-
   /// 알람 삭제 처리 (/alarms/{alarmId})
   Future<RequestResult<bool>> deleteNotification(int alarmId) async {
     return await _send(
-      () async => await delete(
-        '/alarms/$alarmId'
-      ),
+      () async => await delete('/v1/alarms/$alarmId'),
       map: (rp) {
         if (rp.statusCode == HttpStatus.noContent) return true;
         return false;
@@ -225,7 +221,7 @@ class ApiClient extends GetConnect {
     var future = Future<RequestResult<LoginResult>>(() async {
       String? fbToken = await FirebaseAuth.instance.currentUser?.getIdToken();
       return await _send(
-        () async => await post('/auth/social', "$fbToken"),
+        () async => await post('/v1/auth/social', "$fbToken"),
         map: (rp) {
           LoginResult result = LoginResult.fromJson(
             json.decode(rp.bodyString!),
@@ -248,7 +244,7 @@ class ApiClient extends GetConnect {
   /// 현재 사용자 정보 조회 (/users/me) - GET
   Future<RequestResult<AppUser>> getCurrentUser() async {
     return _send(
-      () async => await get('/users/me'),
+      () async => await get('/v1/users/me'),
       map: (rp) {
         AppUser user = AppUser.fromJson(json.decode(rp.bodyString!));
 
@@ -264,7 +260,7 @@ class ApiClient extends GetConnect {
     AlarmSettings alarmSettings,
   ) {
     return _send(
-      () async => await patch('/users/settings', {
+      () async => await patch('/v1/users/settings', {
         'autoAddBookmarkToCalendar': autoAddBookmarkToCalendar,
         'alarmSettings': alarmSettings.toJson(),
       }),
@@ -282,7 +278,7 @@ class ApiClient extends GetConnect {
   Future<RequestResult<bool>> isNicknameAvailable(String nickname) async {
     return _send(
       () async =>
-          await get('/users/check-nickname', query: {'nickname': nickname}),
+          await get('/v1/users/check-nickname', query: {'nickname': nickname}),
       map: (_) => true,
     );
   }
@@ -291,7 +287,7 @@ class ApiClient extends GetConnect {
   Future<RequestResult<bool>> updateCurrentUserNickname(String nickname) async {
     return _send(
       () async => await patch(
-        '/users/nickname',
+        '/v1/users/nickname',
         jsonEncode({'nickname': nickname.trim()}),
       ),
       map: (_) => true,
@@ -300,7 +296,7 @@ class ApiClient extends GetConnect {
 
   /// 회원탈퇴 (/users) - DELETE
   Future<RequestResult<void>> withdrawUser() async {
-    return _send(() async => await delete('/users'), map: (_) => true);
+    return _send(() async => await delete('/v1/users'), map: (_) => true);
   }
 
   /// 알림 - 사용자 기기 등록 (/users/device/{token}) - PATCH
@@ -311,31 +307,31 @@ class ApiClient extends GetConnect {
     }
 
     return _send(
-      () async => await patch('/users/device/$token', {}),
+      () async => await patch('/v1/users/device/$token', {}),
       map: (_) => true,
     );
   }
 
   // ---------- Event ----------
 
-  /// 행사 목록 조회 (/events) - GET
-  Future<RequestResult<List<Event>>> getEvents({
-    bool isApproved = true,
-    bool includeFinished = false,
-    bool isBookmarked = false,
-    int page = 0,
+  /// 행사 목록 조회 (/v2/events) - GET
+  Future<RequestResult<EventsResponse>> getEvents({
+    String? cursor,
+    bool finished = false,
+    bool bookmarked = false,
     int size = 10,
-    SortDirection sortDirection = SortDirection.DESC, // 'ASC' | 'DESC'
-    String field = 'ID', // 'ID' | 'NAME'
-    required List<EventType>
-    types, // 'CONFERENCE' | 'SEMINAR' | 'WEBINAR' | 'WORKSHOP' | 'CONTEST' | 'ETC'
+    String field = 'CREATED_AT',
+    required List<EventType> types,
     int? hostId,
     String? searchKeyword,
   }) async {
     String query =
-        "isApproved=$isApproved&includeFinished=$includeFinished&isBookmarked=$isBookmarked&page=$page&size=$size&sortDirection=${sortDirection.name}&field=$field";
+        "bookmarked=$bookmarked&size=$size&field=$field&statusGroup=${finished ? 'FINISHED' : 'ACTIVE'}";
+    if (cursor != null) {
+      query += "&cursor=$cursor";
+    }
     for (var type in types) {
-      query += "&type=${type.name}";
+      query += "&types=${type.name}";
     }
     if (hostId != null) {
       query += "&hostId=$hostId";
@@ -345,13 +341,10 @@ class ApiClient extends GetConnect {
     }
 
     return _send(
-      () async => await get('/events?$query'),
+      () async => await get('/v2/events?$query'),
       map: (rp) {
-        List<Event> events = [];
-        for (Map ele in List.from(json.decode(rp.bodyString!)['content'])) {
-          events.add(Event.fromJson(Map.from(ele)));
-        }
-        return events;
+        String bodyString = rp.bodyString!;
+        return EventsResponse.fromJson(json.decode(bodyString));
       },
     );
   }
@@ -364,7 +357,7 @@ class ApiClient extends GetConnect {
   }) async {
     return _send(
       () async => await get(
-        '/events/calendar',
+        '/v1/events/calendar',
         query: _cleanQuery({'year': year, 'month': month, 'type': type?.name}),
       ),
       map: (rp) {
@@ -389,7 +382,7 @@ class ApiClient extends GetConnect {
   }) async {
     return _send(
       () async => await get(
-        '/hosts',
+        '/v1/hosts',
         query: _cleanQuery({
           'page': page,
           'size': size,
@@ -413,7 +406,7 @@ class ApiClient extends GetConnect {
   /// 북마크 토글 (/bookmarks/{eventId}) - POST (200)
   Future<RequestResult<bool>> toggleBookmark(int eventId) async {
     return _send(
-      () async => await post('/bookmarks/$eventId', null),
+      () async => await post('/v1/bookmarks/$eventId', null),
       map: (rp) => json.decode(rp.bodyString!)['isBookmarked'] as bool,
     );
   }
@@ -422,7 +415,7 @@ class ApiClient extends GetConnect {
 
   /// 조회수 증가 (/views/{eventId}) - PATCH (204)
   Future<void> increaseViewCount(int eventId) async {
-    await patch('/views/$eventId', null);
+    await patch('/v1/views/$eventId', null);
   }
 }
 

--- a/lib/app/core/enums/event_sorting_type.dart
+++ b/lib/app/core/enums/event_sorting_type.dart
@@ -1,18 +1,16 @@
-import 'package:duty_it/app/core/enums/sort_direction.dart';
 
 enum EventSortingType {
   //ID, NAME, START_DATE, RECRUITMENT_DEADLINE, VIEW_COUNT, CREATED_AT
-  latest('최신 등록순', '최신순', 'ID', SortDirection.DESC),
-  eventStartSoon('행사 날짜 임박순', '행사 날짜', 'START_DATE', SortDirection.ASC),
-  closingSoon('모집 마감 임박순', '모집 마감', 'RECRUITMENT_DEADLINE', SortDirection.ASC),
-  popular('인기순', '인기순', 'VIEW_COUNT', SortDirection.DESC);
+  latest('최신 등록순', '최신순', 'CREATED_AT'),
+  eventStartSoon('행사 날짜 임박순', '행사 날짜', 'START_DATE'),
+  closingSoon('모집 마감 임박순', '모집 마감', 'RECRUITMENT_DEADLINE'),
+  popular('인기순', '인기순', 'VIEW_COUNT');
 
   final String displayName;
   final String shortName; 
   final String field;
-  final SortDirection sortDirection;
 
-  const EventSortingType(this.displayName, this.shortName, this.field, this.sortDirection);
+  const EventSortingType(this.displayName, this.shortName, this.field);
 
   static EventSortingType fromName(String name) {
     try {

--- a/lib/app/core/enums/event_type.dart
+++ b/lib/app/core/enums/event_type.dart
@@ -8,6 +8,8 @@ enum EventType {
   CONTEST('공모전'),
   CONTINUING_EDUCATION("보수교육"),
   EDUCATION("교육"),
+  VOLUNTEER("봉사"),
+  TRAINING("연수"),
   ETC('기타');
    
   final String displayName;

--- a/lib/app/core/enums/event_type.dart
+++ b/lib/app/core/enums/event_type.dart
@@ -5,7 +5,7 @@ enum EventType {
   SEMINAR('세미나'),
   WEBINAR('웨비나'),
   WORKSHOP('워크숍'),
-  CONTEST('콘테스트'),
+  CONTEST('공모전'),
   CONTINUING_EDUCATION("보수교육"),
   EDUCATION("교육"),
   ETC('기타');

--- a/lib/app/core/models/event.g.dart
+++ b/lib/app/core/models/event.g.dart
@@ -56,5 +56,7 @@ const _$EventTypeEnumMap = {
   EventType.CONTEST: 'CONTEST',
   EventType.CONTINUING_EDUCATION: 'CONTINUING_EDUCATION',
   EventType.EDUCATION: 'EDUCATION',
+  EventType.VOLUNTEER: 'VOLUNTEER',
+  EventType.TRAINING: 'TRAINING',
   EventType.ETC: 'ETC',
 };

--- a/lib/app/core/models/events_page_info.dart
+++ b/lib/app/core/models/events_page_info.dart
@@ -1,0 +1,24 @@
+// To parse this JSON data, do
+//
+//     final eventsPageInfo = eventsPageInfoFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'events_page_info.freezed.dart';
+part 'events_page_info.g.dart';
+
+EventsPageInfo eventsPageInfoFromJson(String str) => EventsPageInfo.fromJson(json.decode(str));
+
+String eventsPageInfoToJson(EventsPageInfo data) => json.encode(data.toJson());
+
+@freezed
+abstract class EventsPageInfo with _$EventsPageInfo {
+    const factory EventsPageInfo({
+        required bool hasNext,
+        required String? nextCursor,
+        required int pageSize,
+    }) = _EventsPageInfo;
+
+    factory EventsPageInfo.fromJson(Map<String, dynamic> json) => _$EventsPageInfoFromJson(json);
+}

--- a/lib/app/core/models/events_page_info.freezed.dart
+++ b/lib/app/core/models/events_page_info.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'events_page_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EventsPageInfo {
+
+ bool get hasNext; String? get nextCursor; int get pageSize;
+/// Create a copy of EventsPageInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EventsPageInfoCopyWith<EventsPageInfo> get copyWith => _$EventsPageInfoCopyWithImpl<EventsPageInfo>(this as EventsPageInfo, _$identity);
+
+  /// Serializes this EventsPageInfo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventsPageInfo&&(identical(other.hasNext, hasNext) || other.hasNext == hasNext)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.pageSize, pageSize) || other.pageSize == pageSize));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,hasNext,nextCursor,pageSize);
+
+@override
+String toString() {
+  return 'EventsPageInfo(hasNext: $hasNext, nextCursor: $nextCursor, pageSize: $pageSize)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EventsPageInfoCopyWith<$Res>  {
+  factory $EventsPageInfoCopyWith(EventsPageInfo value, $Res Function(EventsPageInfo) _then) = _$EventsPageInfoCopyWithImpl;
+@useResult
+$Res call({
+ bool hasNext, String? nextCursor, int pageSize
+});
+
+
+
+
+}
+/// @nodoc
+class _$EventsPageInfoCopyWithImpl<$Res>
+    implements $EventsPageInfoCopyWith<$Res> {
+  _$EventsPageInfoCopyWithImpl(this._self, this._then);
+
+  final EventsPageInfo _self;
+  final $Res Function(EventsPageInfo) _then;
+
+/// Create a copy of EventsPageInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? hasNext = null,Object? nextCursor = freezed,Object? pageSize = null,}) {
+  return _then(_self.copyWith(
+hasNext: null == hasNext ? _self.hasNext : hasNext // ignore: cast_nullable_to_non_nullable
+as bool,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,pageSize: null == pageSize ? _self.pageSize : pageSize // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EventsPageInfo].
+extension EventsPageInfoPatterns on EventsPageInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EventsPageInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EventsPageInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EventsPageInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _EventsPageInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EventsPageInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EventsPageInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool hasNext,  String? nextCursor,  int pageSize)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EventsPageInfo() when $default != null:
+return $default(_that.hasNext,_that.nextCursor,_that.pageSize);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool hasNext,  String? nextCursor,  int pageSize)  $default,) {final _that = this;
+switch (_that) {
+case _EventsPageInfo():
+return $default(_that.hasNext,_that.nextCursor,_that.pageSize);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool hasNext,  String? nextCursor,  int pageSize)?  $default,) {final _that = this;
+switch (_that) {
+case _EventsPageInfo() when $default != null:
+return $default(_that.hasNext,_that.nextCursor,_that.pageSize);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _EventsPageInfo implements EventsPageInfo {
+  const _EventsPageInfo({required this.hasNext, required this.nextCursor, required this.pageSize});
+  factory _EventsPageInfo.fromJson(Map<String, dynamic> json) => _$EventsPageInfoFromJson(json);
+
+@override final  bool hasNext;
+@override final  String? nextCursor;
+@override final  int pageSize;
+
+/// Create a copy of EventsPageInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EventsPageInfoCopyWith<_EventsPageInfo> get copyWith => __$EventsPageInfoCopyWithImpl<_EventsPageInfo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EventsPageInfoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventsPageInfo&&(identical(other.hasNext, hasNext) || other.hasNext == hasNext)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.pageSize, pageSize) || other.pageSize == pageSize));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,hasNext,nextCursor,pageSize);
+
+@override
+String toString() {
+  return 'EventsPageInfo(hasNext: $hasNext, nextCursor: $nextCursor, pageSize: $pageSize)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EventsPageInfoCopyWith<$Res> implements $EventsPageInfoCopyWith<$Res> {
+  factory _$EventsPageInfoCopyWith(_EventsPageInfo value, $Res Function(_EventsPageInfo) _then) = __$EventsPageInfoCopyWithImpl;
+@override @useResult
+$Res call({
+ bool hasNext, String? nextCursor, int pageSize
+});
+
+
+
+
+}
+/// @nodoc
+class __$EventsPageInfoCopyWithImpl<$Res>
+    implements _$EventsPageInfoCopyWith<$Res> {
+  __$EventsPageInfoCopyWithImpl(this._self, this._then);
+
+  final _EventsPageInfo _self;
+  final $Res Function(_EventsPageInfo) _then;
+
+/// Create a copy of EventsPageInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? hasNext = null,Object? nextCursor = freezed,Object? pageSize = null,}) {
+  return _then(_EventsPageInfo(
+hasNext: null == hasNext ? _self.hasNext : hasNext // ignore: cast_nullable_to_non_nullable
+as bool,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,pageSize: null == pageSize ? _self.pageSize : pageSize // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/app/core/models/events_page_info.g.dart
+++ b/lib/app/core/models/events_page_info.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'events_page_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EventsPageInfo _$EventsPageInfoFromJson(Map<String, dynamic> json) =>
+    _EventsPageInfo(
+      hasNext: json['hasNext'] as bool,
+      nextCursor: json['nextCursor'] as String?,
+      pageSize: (json['pageSize'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$EventsPageInfoToJson(_EventsPageInfo instance) =>
+    <String, dynamic>{
+      'hasNext': instance.hasNext,
+      'nextCursor': instance.nextCursor,
+      'pageSize': instance.pageSize,
+    };

--- a/lib/app/core/models/events_response.dart
+++ b/lib/app/core/models/events_response.dart
@@ -1,0 +1,25 @@
+// To parse this JSON data, do
+//
+//     final eventsResponse = eventsResponseFromJson(jsonString);
+
+import 'package:duty_it/app/core/models/event.dart';
+import 'package:duty_it/app/core/models/events_page_info.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'events_response.freezed.dart';
+part 'events_response.g.dart';
+
+EventsResponse eventsResponseFromJson(String str) => EventsResponse.fromJson(json.decode(str));
+
+String eventsResponseToJson(EventsResponse data) => json.encode(data.toJson());
+
+@freezed
+abstract class EventsResponse with _$EventsResponse {
+    const factory EventsResponse({
+        @JsonKey(name: 'content') required List<Event> events,
+        required EventsPageInfo pageInfo,
+    }) = _EventsResponse;
+
+    factory EventsResponse.fromJson(Map<String, dynamic> json) => _$EventsResponseFromJson(json);
+}

--- a/lib/app/core/models/events_response.freezed.dart
+++ b/lib/app/core/models/events_response.freezed.dart
@@ -1,0 +1,304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'events_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EventsResponse {
+
+@JsonKey(name: 'content') List<Event> get events; EventsPageInfo get pageInfo;
+/// Create a copy of EventsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EventsResponseCopyWith<EventsResponse> get copyWith => _$EventsResponseCopyWithImpl<EventsResponse>(this as EventsResponse, _$identity);
+
+  /// Serializes this EventsResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventsResponse&&const DeepCollectionEquality().equals(other.events, events)&&(identical(other.pageInfo, pageInfo) || other.pageInfo == pageInfo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(events),pageInfo);
+
+@override
+String toString() {
+  return 'EventsResponse(events: $events, pageInfo: $pageInfo)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EventsResponseCopyWith<$Res>  {
+  factory $EventsResponseCopyWith(EventsResponse value, $Res Function(EventsResponse) _then) = _$EventsResponseCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'content') List<Event> events, EventsPageInfo pageInfo
+});
+
+
+$EventsPageInfoCopyWith<$Res> get pageInfo;
+
+}
+/// @nodoc
+class _$EventsResponseCopyWithImpl<$Res>
+    implements $EventsResponseCopyWith<$Res> {
+  _$EventsResponseCopyWithImpl(this._self, this._then);
+
+  final EventsResponse _self;
+  final $Res Function(EventsResponse) _then;
+
+/// Create a copy of EventsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? events = null,Object? pageInfo = null,}) {
+  return _then(_self.copyWith(
+events: null == events ? _self.events : events // ignore: cast_nullable_to_non_nullable
+as List<Event>,pageInfo: null == pageInfo ? _self.pageInfo : pageInfo // ignore: cast_nullable_to_non_nullable
+as EventsPageInfo,
+  ));
+}
+/// Create a copy of EventsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventsPageInfoCopyWith<$Res> get pageInfo {
+  
+  return $EventsPageInfoCopyWith<$Res>(_self.pageInfo, (value) {
+    return _then(_self.copyWith(pageInfo: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EventsResponse].
+extension EventsResponsePatterns on EventsResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EventsResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EventsResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EventsResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _EventsResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EventsResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EventsResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EventsResponse() when $default != null:
+return $default(_that.events,_that.pageInfo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo)  $default,) {final _that = this;
+switch (_that) {
+case _EventsResponse():
+return $default(_that.events,_that.pageInfo);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo)?  $default,) {final _that = this;
+switch (_that) {
+case _EventsResponse() when $default != null:
+return $default(_that.events,_that.pageInfo);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _EventsResponse implements EventsResponse {
+  const _EventsResponse({@JsonKey(name: 'content') required final  List<Event> events, required this.pageInfo}): _events = events;
+  factory _EventsResponse.fromJson(Map<String, dynamic> json) => _$EventsResponseFromJson(json);
+
+ final  List<Event> _events;
+@override@JsonKey(name: 'content') List<Event> get events {
+  if (_events is EqualUnmodifiableListView) return _events;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_events);
+}
+
+@override final  EventsPageInfo pageInfo;
+
+/// Create a copy of EventsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EventsResponseCopyWith<_EventsResponse> get copyWith => __$EventsResponseCopyWithImpl<_EventsResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EventsResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventsResponse&&const DeepCollectionEquality().equals(other._events, _events)&&(identical(other.pageInfo, pageInfo) || other.pageInfo == pageInfo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_events),pageInfo);
+
+@override
+String toString() {
+  return 'EventsResponse(events: $events, pageInfo: $pageInfo)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EventsResponseCopyWith<$Res> implements $EventsResponseCopyWith<$Res> {
+  factory _$EventsResponseCopyWith(_EventsResponse value, $Res Function(_EventsResponse) _then) = __$EventsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'content') List<Event> events, EventsPageInfo pageInfo
+});
+
+
+@override $EventsPageInfoCopyWith<$Res> get pageInfo;
+
+}
+/// @nodoc
+class __$EventsResponseCopyWithImpl<$Res>
+    implements _$EventsResponseCopyWith<$Res> {
+  __$EventsResponseCopyWithImpl(this._self, this._then);
+
+  final _EventsResponse _self;
+  final $Res Function(_EventsResponse) _then;
+
+/// Create a copy of EventsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? events = null,Object? pageInfo = null,}) {
+  return _then(_EventsResponse(
+events: null == events ? _self._events : events // ignore: cast_nullable_to_non_nullable
+as List<Event>,pageInfo: null == pageInfo ? _self.pageInfo : pageInfo // ignore: cast_nullable_to_non_nullable
+as EventsPageInfo,
+  ));
+}
+
+/// Create a copy of EventsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventsPageInfoCopyWith<$Res> get pageInfo {
+  
+  return $EventsPageInfoCopyWith<$Res>(_self.pageInfo, (value) {
+    return _then(_self.copyWith(pageInfo: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/app/core/models/events_response.g.dart
+++ b/lib/app/core/models/events_response.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'events_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EventsResponse _$EventsResponseFromJson(Map<String, dynamic> json) =>
+    _EventsResponse(
+      events: (json['content'] as List<dynamic>)
+          .map((e) => Event.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      pageInfo: EventsPageInfo.fromJson(
+        json['pageInfo'] as Map<String, dynamic>,
+      ),
+    );
+
+Map<String, dynamic> _$EventsResponseToJson(_EventsResponse instance) =>
+    <String, dynamic>{
+      'content': instance.events.map((e) => e.toJson()).toList(),
+      'pageInfo': instance.pageInfo.toJson(),
+    };

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -26,7 +26,7 @@ import 'package:synchronized/synchronized.dart';
 
 enum HomeTab { event, bookmark }
 
-class HomeViewController extends GetxController with WidgetsBindingObserver {
+class HomeViewController extends GetxController {
   final FirebaseAnalytics analytics = FirebaseAnalytics.instance;
   final ScrollController scrollController = ScrollController();
 
@@ -62,8 +62,6 @@ class HomeViewController extends GetxController with WidgetsBindingObserver {
   WidgetsBinding get binding => WidgetsBinding.instance;
   bool get isForeground => binding.lifecycleState == AppLifecycleState.resumed;
 
-  Timer? _newNotiTimer;
-
   @override
   void onInit() {
     super.onInit();
@@ -98,40 +96,6 @@ class HomeViewController extends GetxController with WidgetsBindingObserver {
     );
 
     checkNewNotification();
-    binding.addObserver(this);
-    if (isForeground) {
-      _startNewNotiTimer();
-    }
-  }
-
-  @override
-  void onClose() {
-    _stopNewNotiTimer();
-    binding.removeObserver(this);
-    super.onClose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    super.didChangeAppLifecycleState(state);
-
-    if (isForeground) {
-      _startNewNotiTimer();
-    } else {
-      _stopNewNotiTimer();
-    }
-  }
-
-  void _startNewNotiTimer() {
-    _stopNewNotiTimer();
-    _newNotiTimer = Timer.periodic(
-      Duration(seconds: 10),
-      (_) => checkNewNotification(),
-    );
-  }
-
-  void _stopNewNotiTimer() {
-    _newNotiTimer?.cancel();
   }
 
   Future<void> checkNewNotification() async {

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/core/enums/event_sorting_type.dart';
+import 'package:duty_it/app/core/models/events_response.dart';
 import 'package:duty_it/app/modules/notifications/models/app_notification.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:duty_it/app/services/event/events/event_bookmark_event.dart';
@@ -34,19 +35,20 @@ class HomeViewController extends GetxController {
   AppSettingsService get _settingsService => Get.find<AppSettingsService>();
   AppEventService get _eventService => Get.find<AppEventService>();
 
-  final Rx<PagingState<int, EventCard>> _pagingState =
-      PagingState<int, EventCard>().obs;
-  PagingState<int, EventCard> get pagingState => _pagingState.value;
+  final Rx<PagingState<String?, EventCard>> _pagingState =
+      PagingState<String?, EventCard>().obs;
+  PagingState<String?, EventCard> get pagingState => _pagingState.value;
   set pagingState(state) => _pagingState.value = state;
 
   final Rx<HomeTab> _selectedTab = HomeTab.event.obs;
   set selectedTab(HomeTab tab) {
     if (tab != HomeTab.event && !Get.find<AuthService>().isLoggined()) {
       Get.toNamed(Routes.LOGIN);
-      return;  
+      return;
     }
     _selectedTab.value = tab;
   }
+
   HomeTab get selectedTab => _selectedTab.value;
 
   EventSortingType get sortingType => _settingsService.eventSortingType;
@@ -56,6 +58,7 @@ class HomeViewController extends GetxController {
   final RxString searchQuery = RxString('');
 
   final Lock _fetchPageLock = Lock();
+  bool onlyFinishedMode = false;
 
   final RxBool _hasNewNotification = RxBool(false);
   bool get hasNewNotification => _hasNewNotification.value;
@@ -72,14 +75,10 @@ class HomeViewController extends GetxController {
       () => searchQuery.value = searchTextEditingController.text.trim(),
     );
 
-    debounce(
-      searchQuery,
-      (v) async {
-        analytics.logSearch(searchTerm: searchQuery.value);
-        await fetchNextPage(clearPage: true);
-      },
-      time: Duration(milliseconds: 500),
-    );
+    debounce(searchQuery, (v) async {
+      analytics.logSearch(searchTerm: searchQuery.value);
+      await fetchNextPage(clearPage: true);
+    }, time: Duration(milliseconds: 500));
 
     ever(_selectedTab, (_) async {
       HapticFeedback.lightImpact();
@@ -104,9 +103,11 @@ class HomeViewController extends GetxController {
       _hasNewNotification.value = false;
       return;
     }
-    
+
     var api = Get.find<ApiClient>();
-    RequestResult<List<AppNotification>> result = await api.getNotificationList(0);
+    RequestResult<List<AppNotification>> result = await api.getNotificationList(
+      0,
+    );
     if (result is RequestFail) return;
 
     List<AppNotification> notiList = (result as RequestSuccess).data;
@@ -120,7 +121,11 @@ class HomeViewController extends GetxController {
   }
 
   void scrollUpEventList() {
-    scrollController.animateTo(0, duration: Duration(milliseconds: 300), curve: Curves.ease);
+    scrollController.animateTo(
+      0,
+      duration: Duration(milliseconds: 300),
+      curve: Curves.ease,
+    );
   }
 
   Future<void> fetchNextPage({bool clearPage = false}) async {
@@ -128,19 +133,13 @@ class HomeViewController extends GetxController {
       SearchFilterService sfService = Get.find<SearchFilterService>();
 
       // Update paging state
+      if (clearPage) onlyFinishedMode = false;
       pagingState = pagingState.copyWith(
         isLoading: true,
         error: null,
         keys: clearPage ? null : const Omit(),
         pages: clearPage ? null : const Omit(),
       );
-
-      // find next key
-      int nextKey = 0;
-      if (!clearPage &&
-          !(pagingState.keys == null || pagingState.keys!.isEmpty)) {
-        nextKey = pagingState.keys!.last + 1;
-      }
 
       // set params
       const int size = 5;
@@ -152,31 +151,51 @@ class HomeViewController extends GetxController {
         types.add(EventType.getByDisplayName(category));
       }
 
+      String? pageKey = pagingState.keys?.last;
       int? hostId = sfService.filter.host?.id;
-      bool includeFinished = sfService.filter.showEnded;
+
+      if (!onlyFinishedMode) {
+        if (pageKey == null &&
+            sfService.filter.showEnded &&
+            (pagingState.keys?.isNotEmpty ?? false)) {
+          onlyFinishedMode = true;
+        }
+      }
 
       // request
 
       try {
         var apiClient = Get.find<ApiClient>();
         var reqResult = await apiClient.getEvents(
-          isApproved: true,
-          includeFinished: includeFinished,
-          isBookmarked: selectedTab == HomeTab.bookmark,
-          page: nextKey,
+          finished: onlyFinishedMode,
+          bookmarked: selectedTab == HomeTab.bookmark,
+          cursor: pageKey,
           size: size,
-          sortDirection: sortingType.sortDirection,
           field: sortingType.field,
           searchKeyword: searchQuery.isEmpty ? null : searchQuery.value,
           hostId: hostId,
           types: types,
         );
         if (reqResult is RequestSuccess) {
-          var events = (reqResult as RequestSuccess<List<Event>>).data;
+          EventsResponse response =
+              (reqResult as RequestSuccess<EventsResponse>).data;
+          var pageInfo = response.pageInfo;
+          var events = response.events;
+
+          bool hasNext;
+          if (sfService.filter.showEnded) {
+            if (onlyFinishedMode) {
+              hasNext = pageInfo.hasNext;
+            } else {
+              hasNext = true;
+            }
+          } else {
+            hasNext = pageInfo.hasNext;
+          }
 
           pagingState = pagingState.copyWith(
             isLoading: false,
-            keys: [...pagingState.keys ?? [], nextKey],
+            keys: [...pagingState.keys ?? [], pageInfo.nextCursor],
             pages: [
               ...pagingState.pages ?? [],
               List<EventCard>.generate(
@@ -184,7 +203,7 @@ class HomeViewController extends GetxController {
                 (i) => EventCard(eventRx: Rx(events[i])),
               ),
             ],
-            hasNextPage: events.length >= size,
+            hasNextPage: hasNext,
           );
         } else {
           var fail = reqResult as RequestFail;
@@ -268,7 +287,10 @@ class HomeViewController extends GetxController {
           ],
         );
       } else {
-        analytics.logEvent(name: 'unbookmark', parameters: {'event_id': event.id.toString()});
+        analytics.logEvent(
+          name: 'unbookmark',
+          parameters: {'event_id': event.id.toString()},
+        );
       }
     } else {
       var reqFail = result as RequestFail;

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/core/enums/event_sorting_type.dart';
+import 'package:duty_it/app/modules/notifications/models/app_notification.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:duty_it/app/services/event/events/event_bookmark_event.dart';
 import 'package:duty_it/app/core/utils/app_utils.dart';
@@ -99,7 +100,23 @@ class HomeViewController extends GetxController {
   }
 
   Future<void> checkNewNotification() async {
-    _hasNewNotification.value = false;
+    if (!Get.find<AuthService>().isLoggined()) {
+      _hasNewNotification.value = false;
+      return;
+    }
+    
+    var api = Get.find<ApiClient>();
+    RequestResult<List<AppNotification>> result = await api.getNotificationList(0);
+    if (result is RequestFail) return;
+
+    List<AppNotification> notiList = (result as RequestSuccess).data;
+    if (notiList.isEmpty) {
+      _hasNewNotification.value = false;
+      return;
+    }
+
+    AppNotification noti = notiList.first;
+    _hasNewNotification.value = !noti.isRead;
   }
 
   void scrollUpEventList() {
@@ -261,7 +278,8 @@ class HomeViewController extends GetxController {
     return isBookmarked;
   }
 
-  void openNotificationsPage() {
-    Get.toNamed(Routes.NOTIFICATIONS);
+  Future<void> openNotificationsPage() async {
+    await Get.toNamed(Routes.NOTIFICATIONS);
+    checkNewNotification();
   }
 }

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -28,6 +28,7 @@ enum HomeTab { event, bookmark }
 
 class HomeViewController extends GetxController with WidgetsBindingObserver {
   final FirebaseAnalytics analytics = FirebaseAnalytics.instance;
+  final ScrollController scrollController = ScrollController();
 
   AppSettingsService get _settingsService => Get.find<AppSettingsService>();
   AppEventService get _eventService => Get.find<AppEventService>();
@@ -135,6 +136,10 @@ class HomeViewController extends GetxController with WidgetsBindingObserver {
 
   Future<void> checkNewNotification() async {
     _hasNewNotification.value = false;
+  }
+
+  void scrollUpEventList() {
+    scrollController.animateTo(0, duration: Duration(milliseconds: 300), curve: Curves.ease);
   }
 
   Future<void> fetchNextPage({bool clearPage = false}) async {

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -107,6 +107,7 @@ class HomeViewController extends GetxController {
     var api = Get.find<ApiClient>();
     RequestResult<List<AppNotification>> result = await api.getNotificationList(
       0,
+      size: 1
     );
     if (result is RequestFail) return;
 

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -19,6 +19,7 @@ class HomeView extends GetView<HomeViewController> {
       child: RefreshIndicator.adaptive(
         onRefresh: () async {
           await controller.fetchNextPage(clearPage: true);
+          controller.checkNewNotification();
         },
         child: CustomScrollView(
           physics: AlwaysScrollableScrollPhysics(),

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -21,6 +21,7 @@ class HomeView extends GetView<HomeViewController> {
           await controller.fetchNextPage(clearPage: true);
         },
         child: CustomScrollView(
+          physics: AlwaysScrollableScrollPhysics(),
           controller: controller.scrollController,
           slivers: [
             SliverAppBar(

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -21,6 +21,7 @@ class HomeView extends GetView<HomeViewController> {
           await controller.fetchNextPage(clearPage: true);
         },
         child: CustomScrollView(
+          controller: controller.scrollController,
           slivers: [
             SliverAppBar(
               backgroundColor: Colors.white,

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -41,7 +41,7 @@ class HomeView extends GetView<HomeViewController> {
             ),
 
             Obx(() {
-              return PagedSliverList<int, EventCard>(
+              return PagedSliverList<String?, EventCard>(
                 state: controller.pagingState,
                 fetchNextPage: controller.fetchNextPage,
                 builderDelegate: PagedChildBuilderDelegate<EventCard>(

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -4,6 +4,8 @@ import 'package:duty_it/app/core/constants/app_colors.dart';
 import 'package:duty_it/app/core/utils/app_utils.dart';
 import 'package:duty_it/app/core/models/event.dart';
 import 'package:duty_it/app/modules/home/widgets/event_bookmark_button.dart';
+import 'package:duty_it/app/routes/app_pages.dart';
+import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:duty_it/app/widgets/adaptive_layout.dart';
 import 'package:duty_it/app/widgets/tap_scale.dart';
 import 'package:duty_it/gen/assets.gen.dart';
@@ -33,6 +35,11 @@ class EventCard extends StatelessWidget {
   }
 
   void _onTap() {
+    if (!Get.find<AuthService>().isLoggined()) {
+      Get.toNamed(Routes.LOGIN);
+      return;
+    }
+    
     launchUrlString(event.uri);
 
     var apiClient = Get.find<ApiClient>();

--- a/lib/app/modules/login/views/login_view.dart
+++ b/lib/app/modules/login/views/login_view.dart
@@ -58,7 +58,7 @@ class LoginView extends GetView<LoginViewController> {
                             ),
                           ),
                           Text(
-                            '10초만에 로그인하고 모든 기능을 이용해보세요!',
+                            '10초만에 로그인하고 모든 기능을 이용해보세요.',
                             style: TextStyle(
                               color: AppColors.g07,
                               fontWeight: FontWeight.w300,

--- a/lib/app/modules/login/views/login_view.dart
+++ b/lib/app/modules/login/views/login_view.dart
@@ -28,13 +28,44 @@ class LoginView extends GetView<LoginViewController> {
                   child: Column(
                     children: [
                       Spacer(),
-                      Hero(
-                        tag: SplashView.heroKey,
-                        child: Image.asset(
-                          Assets.icons.logo.path,
-                          width: 84,
-                          height: 80,
-                        ),
+                      Column(
+                        spacing: 10,
+                        children: [
+                          RichText(
+                            text: TextSpan(
+                              style: TextStyle(
+                                fontSize: 30,
+                                fontWeight: FontWeight.w900,
+                              ),
+                              children: [
+                                TextSpan(
+                                  text: "듀잇",
+                                  style: TextStyle(color: AppColors.main),
+                                ),
+                                WidgetSpan(
+                                  alignment: PlaceholderAlignment.middle,
+                                  child: Hero(
+                                    tag: SplashView.heroKey,
+                                    child: Image.asset(
+                                      Assets.icons.logo.path,
+                                      width: 29,
+                                      height: 25,
+                                    ),
+                                  ),
+                                ),
+                                TextSpan(text: "과 함께,\n모든 간호 행사를 한눈에!"),
+                              ],
+                            ),
+                          ),
+                          Text(
+                            '10초만에 로그인하고 모든 기능을 이용해보세요!',
+                            style: TextStyle(
+                              color: AppColors.g07,
+                              fontWeight: FontWeight.w300,
+                              fontSize: 15,
+                            ),
+                          ),
+                        ],
                       ),
                       Spacer(),
                       Column(
@@ -47,14 +78,6 @@ class LoginView extends GetView<LoginViewController> {
                     onTap: () async =>
                         controller.onLoginButtonTap(SocialProvider.kakao),
                   ),*/
-                          Text(
-                            '10초만에 로그인하고 모든 기능을 이용해보세요!',
-                            style: TextStyle(
-                              color: AppColors.g07,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 15,
-                            ),
-                          ),
                           LoginButton(
                             iconPath: Assets.icons.appleWhite.path,
                             buttonColor: Color(0xFF000000),

--- a/lib/app/modules/main/controllers/main_view_controller.dart
+++ b/lib/app/modules/main/controllers/main_view_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/modules/calendar/views/calendar_view.dart';
+import 'package:duty_it/app/modules/home/controllers/home_view_controller.dart';
 import 'package:duty_it/app/modules/home/views/home_view.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -50,6 +51,14 @@ class MainViewController extends GetxController {
   }
 
   void changeTab(int index) {
+    if (pageIndex.value == index) {
+      if (index == 0 && Get.isRegistered<HomeViewController>()) { // Home
+        var homeController = Get.find<HomeViewController>();
+        homeController.scrollUpEventList();
+      }
+      return;
+    }
+
     pageIndex.value = index;
 
     FirebaseAnalytics.instance.logScreenView(screenName: pageNames[index]);

--- a/lib/app/modules/main/widgets/drawer/drawer_category_section.dart
+++ b/lib/app/modules/main/widgets/drawer/drawer_category_section.dart
@@ -40,6 +40,13 @@ class DrawerCategorySection extends StatelessWidget {
             Get.find<MainViewController>().closeEndDrawer();
           },
         ),
+        _PageItemButton(
+          title: "피드백 남기기",
+          onTap: () async {
+            launchUrlString('https://forms.gle/YEUFTzspFMu6xoNW8');
+            Get.find<MainViewController>().closeEndDrawer();
+          },
+        ),
       ],
     );
   }

--- a/lib/app/modules/main/widgets/drawer/drawer_category_section.dart
+++ b/lib/app/modules/main/widgets/drawer/drawer_category_section.dart
@@ -34,7 +34,7 @@ class DrawerCategorySection extends StatelessWidget {
             },
           ),
         _PageItemButton(
-          title: "행사 제보",
+          title: "행사 제보하기",
           onTap: () async {
             launchUrlString('https://www.dutyit.net/submit-event');
             Get.find<MainViewController>().closeEndDrawer();

--- a/lib/app/services/auth/auth_service.dart
+++ b/lib/app/services/auth/auth_service.dart
@@ -130,7 +130,7 @@ class AuthService extends GetxService {
       return false;
     }
 
-    var reqResult = await Get.find<ApiClient>().withdrawUser(appUser!.id);
+    var reqResult = await Get.find<ApiClient>().withdrawUser();
     if (reqResult is RequestFail) {
       AppUtils.showSnackBar('회원탈퇴 중 오류가 발생했어요.');
       if (reqResult.serverFail != null) {

--- a/lib/app/services/auth/auth_service.dart
+++ b/lib/app/services/auth/auth_service.dart
@@ -139,6 +139,7 @@ class AuthService extends GetxService {
       return false;
     }
 
+    await FirebaseAuth.instance.currentUser!.delete();
     await logout();
     return true;
   }


### PR DESCRIPTION
# 작업 내용
- 행사 목록 조회 V2으로  마이그레이션
- 회원탈퇴시 Firebase 회원 탈퇴
- 홈 탭을 추가적으로 터치한 경우 최상단으로 스크롤하는 기능 추가
- 행사 type "CONTEST"를 콘테스트에서 공모전으로 명칭 변경
- 비로그인 상태에서 행사 클릭시 로그인 요구하도록 변경
- 새 알림 여부 확인 로직 수정 및 구현
- 회원탈퇴 API V2 사용
- 로그인 화면 디자인 수정 
- 행사 개수가 3개 미만일 때도 당겨서 새로 고침 가능하도록 수정
- 새 알림 여부 확인 성능 개선
- 행사 종류 (봉사, 연수) 추가
- Drawer에 피드백 버튼 추가

# 테스트 할 것  
- [x] 로그인 화면 디자인 확인
- [x] 행사 목록 조회 기능 정상 작동 여부 확인
- [x] 새 알림 조회 기능 확인
- [x] 회원탈퇴 기능 확인
- [ ] 새 행사 타입 정상 표시 확인