### PR TITLE
2025-12-11 베타 배포 (build 68)

### DIFF
--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -221,6 +221,10 @@ class ApiClient extends GetConnect {
 
     var future = Future<RequestResult<LoginResult>>(() async {
       String? fbToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+      if (fbToken == null) {
+        return RequestFail(null);
+      }
+
       return await _send(
         () async => await post('/v1/auth/social', "$fbToken"),
         map: (rp) {

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -193,7 +193,6 @@ class HomeViewController extends GetxController {
         }
 
         pagingState = pagingState.copyWith(
-          isLoading: false,
           keys: [...pagingState.keys ?? [], pageInfo.nextCursor],
           pages: [
             ...pagingState.pages ?? [],

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -24,7 +24,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
-import 'package:synchronized/synchronized.dart';
 
 enum HomeTab { event, bookmark }
 
@@ -57,7 +56,6 @@ class HomeViewController extends GetxController {
       TextEditingController();
   final RxString searchQuery = RxString('');
 
-  final Lock _fetchPageLock = Lock();
   bool onlyFinishedMode = false;
 
   final RxBool _hasNewNotification = RxBool(false);
@@ -130,94 +128,93 @@ class HomeViewController extends GetxController {
   }
 
   Future<void> fetchNextPage({bool clearPage = false}) async {
-    await _fetchPageLock.synchronized(() async {
-      SearchFilterService sfService = Get.find<SearchFilterService>();
+    if (pagingState.isLoading) return;
+    SearchFilterService sfService = Get.find<SearchFilterService>();
 
-      // Update paging state
-      if (clearPage) onlyFinishedMode = false;
-      pagingState = pagingState.copyWith(
-        isLoading: true,
-        error: null,
-        keys: clearPage ? null : const Omit(),
-        pages: clearPage ? null : const Omit(),
+    // Update paging state
+    if (clearPage) onlyFinishedMode = false;
+    pagingState = pagingState.copyWith(
+      isLoading: true,
+      error: null,
+      keys: clearPage ? null : const Omit(),
+      pages: clearPage ? null : const Omit(),
+    );
+
+    // set params
+    const int size = 5;
+    var filter = sfService.filter;
+    List<String> categories = filter.categories.toList();
+    List<EventType> types = [];
+
+    for (var category in categories) {
+      types.add(EventType.getByDisplayName(category));
+    }
+
+    String? pageKey = pagingState.keys?.last;
+    int? hostId = sfService.filter.host?.id;
+
+    if (!onlyFinishedMode) {
+      if (pageKey == null &&
+          sfService.filter.showEnded &&
+          (pagingState.keys?.isNotEmpty ?? false)) {
+        onlyFinishedMode = true;
+      }
+    }
+
+    // request
+
+    try {
+      var apiClient = Get.find<ApiClient>();
+      var reqResult = await apiClient.getEvents(
+        finished: onlyFinishedMode,
+        bookmarked: selectedTab == HomeTab.bookmark,
+        cursor: pageKey,
+        size: size,
+        field: sortingType.field,
+        searchKeyword: searchQuery.isEmpty ? null : searchQuery.value,
+        hostId: hostId,
+        types: types,
       );
+      if (reqResult is RequestSuccess) {
+        EventsResponse response =
+            (reqResult as RequestSuccess<EventsResponse>).data;
+        var pageInfo = response.pageInfo;
+        var events = response.events;
 
-      // set params
-      const int size = 5;
-      var filter = sfService.filter;
-      List<String> categories = filter.categories.toList();
-      List<EventType> types = [];
-
-      for (var category in categories) {
-        types.add(EventType.getByDisplayName(category));
-      }
-
-      String? pageKey = pagingState.keys?.last;
-      int? hostId = sfService.filter.host?.id;
-
-      if (!onlyFinishedMode) {
-        if (pageKey == null &&
-            sfService.filter.showEnded &&
-            (pagingState.keys?.isNotEmpty ?? false)) {
-          onlyFinishedMode = true;
-        }
-      }
-
-      // request
-
-      try {
-        var apiClient = Get.find<ApiClient>();
-        var reqResult = await apiClient.getEvents(
-          finished: onlyFinishedMode,
-          bookmarked: selectedTab == HomeTab.bookmark,
-          cursor: pageKey,
-          size: size,
-          field: sortingType.field,
-          searchKeyword: searchQuery.isEmpty ? null : searchQuery.value,
-          hostId: hostId,
-          types: types,
-        );
-        if (reqResult is RequestSuccess) {
-          EventsResponse response =
-              (reqResult as RequestSuccess<EventsResponse>).data;
-          var pageInfo = response.pageInfo;
-          var events = response.events;
-
-          bool hasNext;
-          if (sfService.filter.showEnded) {
-            if (onlyFinishedMode) {
-              hasNext = pageInfo.hasNext;
-            } else {
-              hasNext = true;
-            }
-          } else {
+        bool hasNext;
+        if (sfService.filter.showEnded) {
+          if (onlyFinishedMode) {
             hasNext = pageInfo.hasNext;
+          } else {
+            hasNext = true;
           }
-
-          pagingState = pagingState.copyWith(
-            isLoading: false,
-            keys: [...pagingState.keys ?? [], pageInfo.nextCursor],
-            pages: [
-              ...pagingState.pages ?? [],
-              List<EventCard>.generate(
-                events.length,
-                (i) => EventCard(eventRx: Rx(events[i])),
-              ),
-            ],
-            hasNextPage: hasNext,
-          );
         } else {
-          var fail = reqResult as RequestFail;
-          if (kDebugMode) {
-            AppUtils.showSnackBar(
-              '이벤트 목록을 불러오지 못했습니다: ${fail.serverFail?.message ?? ""}',
-            );
-          }
+          hasNext = pageInfo.hasNext;
         }
-      } finally {
-        pagingState = pagingState.copyWith(isLoading: false);
+
+        pagingState = pagingState.copyWith(
+          isLoading: false,
+          keys: [...pagingState.keys ?? [], pageInfo.nextCursor],
+          pages: [
+            ...pagingState.pages ?? [],
+            List<EventCard>.generate(
+              events.length,
+              (i) => EventCard(eventRx: Rx(events[i])),
+            ),
+          ],
+          hasNextPage: hasNext,
+        );
+      } else {
+        var fail = reqResult as RequestFail;
+        if (kDebugMode) {
+          AppUtils.showSnackBar(
+            '이벤트 목록을 불러오지 못했습니다: ${fail.serverFail?.message ?? ""}',
+          );
+        }
       }
-    });
+    } finally {
+      pagingState = pagingState.copyWith(isLoading: false);
+    }
   }
 
   void showSortingBottomModal() {

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -24,6 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:synchronized/synchronized.dart';
 
 enum HomeTab { event, bookmark }
 
@@ -56,6 +57,8 @@ class HomeViewController extends GetxController {
       TextEditingController();
   final RxString searchQuery = RxString('');
 
+  Future<void>? _pageFetchFuture = null;
+  final Lock _pageFetchLock = Lock();
   bool onlyFinishedMode = false;
 
   final RxBool _hasNewNotification = RxBool(false);
@@ -105,7 +108,7 @@ class HomeViewController extends GetxController {
     var api = Get.find<ApiClient>();
     RequestResult<List<AppNotification>> result = await api.getNotificationList(
       0,
-      size: 1
+      size: 1,
     );
     if (result is RequestFail) return;
 
@@ -128,7 +131,11 @@ class HomeViewController extends GetxController {
   }
 
   Future<void> fetchNextPage({bool clearPage = false}) async {
-    if (pagingState.isLoading) return;
+    if (!clearPage && pagingState.isLoading) return;
+    await _pageFetchLock.synchronized(() async => await _fetchNextPage(clearPage: clearPage));
+  }
+
+  Future<void> _fetchNextPage({bool clearPage = false}) async {
     SearchFilterService sfService = Get.find<SearchFilterService>();
 
     // Update paging state

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,6 +67,9 @@ void main() async {
       title: "듀잇 - Du it!",
       initialRoute: AppPages.INITIAL,
       getPages: AppPages.routes,
+      builder: (context, child) {
+        return Overlay(initialEntries: [OverlayEntry(builder: (_) => child!)]);
+      },
       navigatorObservers: [
         FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
       ],


### PR DESCRIPTION
이번 배포(PR)에서는 1.3.0 [build 66](https://github.com/jungwuk-ryu/duty-it/pull/98) 및 [build 67](https://github.com/jungwuk-ryu/duty-it/pull/100)에서 발견된 이슈를 수정합니다.
# 이전 버전에서 발견된 이슈
- 종료된 행사 **안 보기** 설정 상태에서 행사 목록 조회시 페이지가 끝 없이 로드됨
- 비로그인 상태에서도 로그인 API를 요청함. 과거부터 있었던 이슈이지만, 최근 앱 사용자가 늘어나면서 서버에 불필요한 로그가 쌓이고 개발자에게 혼란을 줌
- 스낵바가 노출되지 않음

# 주요 작업
- 행사 목록 패치 중일 때엔 패치 메서드가 early return하여 중복 요청을 방지
- Firebase에 로그인 상태가 아닌 경우(token == null) 서버에 토근 요청(로그인) API 요청을 보내지 않도록 수정
- [최신 버전 Flutter에서 발생하는 GetX SnackBar](https://github.com/jonataslaw/getx/issues/3425) 이슈 해결 시도