### PR TITLE
v1.3.1 릴리즈 배포 

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -35,6 +35,8 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -220,7 +220,14 @@ class ApiClient extends GetConnect {
     }
 
     var future = Future<RequestResult<LoginResult>>(() async {
-      String? fbToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+      String? fbToken;
+
+      try {
+        fbToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+      } catch (ex, st) {
+        FirebaseCrashlytics.instance.recordError(ex, st);
+      }
+
       if (fbToken == null) {
         return RequestFail(null);
       }

--- a/lib/app/core/utils/app_utils.dart
+++ b/lib/app/core/utils/app_utils.dart
@@ -78,4 +78,17 @@ class AppUtils {
     await Get.deleteAll(force: true);
     Get.offAllNamed(Routes.SPLASH);
   }
+  
+  static Uri setDuitUtmSource(Uri uri) {
+    return uri.replace(
+      queryParameters: {
+        ... uri.queryParameters,
+        'utm_source': 'www.dutyit.net'
+      }
+    );
+  }
+
+  static String setDuitUtmSourceString(String uri) {
+    return setDuitUtmSource(Uri.parse(uri)).toString();
+  }
 }

--- a/lib/app/modules/calendar/controllers/calendar_view_controller.dart
+++ b/lib/app/modules/calendar/controllers/calendar_view_controller.dart
@@ -44,7 +44,6 @@ class CalendarViewController extends GetxController {
   }
 
   void showDateSelectionBottomModal() {
-    Get.put(DateSelectionModalController());
     showModalBottomSheet(
       context: Get.context!,
       isScrollControlled: true,
@@ -52,7 +51,7 @@ class CalendarViewController extends GetxController {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (_) => DateSelectionBottomModal(),
-    ).whenComplete(() => Get.delete<DateSelectionModalController>());
+    );
   }
 
   String _dateTimeToCacheKey(DateTime dt) {

--- a/lib/app/modules/calendar/widgets/custom_calendar_event_card.dart
+++ b/lib/app/modules/calendar/widgets/custom_calendar_event_card.dart
@@ -27,7 +27,7 @@ class CustomCalendarEventCard extends StatelessWidget {
       child: InkWell(
         onTap: () {
           if (event != null) {
-            launchUrlString(event!.url);
+            launchUrlString(AppUtils.setDuitUtmSourceString(event!.url));
           }
         },
         child: ConstrainedBox(

--- a/lib/app/modules/calendar/widgets/date_selection_bottom_modal.dart
+++ b/lib/app/modules/calendar/widgets/date_selection_bottom_modal.dart
@@ -9,11 +9,28 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:scroll_snap_list/scroll_snap_list.dart';
 
-class DateSelectionBottomModal extends StatelessWidget {
+class DateSelectionBottomModal extends StatefulWidget {
+  const DateSelectionBottomModal({super.key});
+
+  @override
+  State<DateSelectionBottomModal> createState() => _DateSelectionBottomModalState();
+}
+
+class _DateSelectionBottomModalState extends State<DateSelectionBottomModal> {
   DateSelectionModalController get controller =>
       Get.find<DateSelectionModalController>();
 
-  const DateSelectionBottomModal({super.key});
+  @override
+  void initState() {
+    Get.put(DateSelectionModalController());
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    Get.delete<DateSelectionModalController>();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -57,7 +57,6 @@ class HomeViewController extends GetxController {
       TextEditingController();
   final RxString searchQuery = RxString('');
 
-  Future<void>? _pageFetchFuture = null;
   final Lock _pageFetchLock = Lock();
   bool onlyFinishedMode = false;
 
@@ -169,7 +168,7 @@ class HomeViewController extends GetxController {
     }
 
     // request
-
+    FirebaseAnalytics.instance.logEvent(name: 'fetch_events_page', parameters: {'clear_page': "$clearPage"});
     try {
       var apiClient = Get.find<ApiClient>();
       var reqResult = await apiClient.getEvents(

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -223,7 +223,6 @@ class HomeViewController extends GetxController {
   }
 
   void showSortingBottomModal() {
-    Get.put<SortingModalController>(SortingModalController());
     showModalBottomSheet(
       context: Get.context!,
       isScrollControlled: true,
@@ -231,7 +230,7 @@ class HomeViewController extends GetxController {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (_) => SortingBottomModal(),
-    ).whenComplete(() => Get.delete<SortingModalController>());
+    );
   }
 
   Future<void> onBookmarkButtonClick(Rx<Event> eventRx) async {
@@ -252,17 +251,15 @@ class HomeViewController extends GetxController {
     );
 
     if (!event.isBookmarked && !appSettings.dontShowAutoAddModal.value) {
-      Get.put<BookmarkModalController>(
-        BookmarkModalController(eventRx: eventRx),
-      );
+      
       showModalBottomSheet(
         context: Get.context!,
         isScrollControlled: true,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
         ),
-        builder: (_) => BookmarkBottomModal(),
-      ).whenComplete(() => Get.delete<BookmarkModalController>());
+        builder: (_) => BookmarkBottomModal(eventRx: eventRx),
+      );
     } else {
       eventRx.value = event.copyWith(isBookmarked: !event.isBookmarked);
 

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -40,7 +40,7 @@ class EventCard extends StatelessWidget {
       return;
     }
     
-    launchUrlString(event.uri);
+    launchUrlString(AppUtils.setDuitUtmSourceString(event.uri));
 
     var apiClient = Get.find<ApiClient>();
     apiClient.increaseViewCount(event.id);

--- a/lib/app/modules/home/widgets/modal/bookmark_bottom_modal.dart
+++ b/lib/app/modules/home/widgets/modal/bookmark_bottom_modal.dart
@@ -1,14 +1,36 @@
 import 'package:duty_it/app/core/constants/app_colors.dart';
+import 'package:duty_it/app/core/models/event.dart';
 import 'package:duty_it/app/modules/home/controllers/bookmark_modal_controller.dart';
 import 'package:duty_it/app/widgets/app_normal_button.dart';
 import 'package:duty_it/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class BookmarkBottomModal extends StatelessWidget {
+class BookmarkBottomModal extends StatefulWidget {
+  final Rx<Event> eventRx;
+  
+  const BookmarkBottomModal({super.key, required this.eventRx});
+
+  @override
+  State<BookmarkBottomModal> createState() => _BookmarkBottomModalState();
+}
+
+class _BookmarkBottomModalState extends State<BookmarkBottomModal> {
   BookmarkModalController get controller => Get.find<BookmarkModalController>();
 
-  const BookmarkBottomModal({super.key});
+  @override
+  void initState() {
+    Get.put<BookmarkModalController>(
+        BookmarkModalController(eventRx: widget.eventRx),
+      );
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    Get.delete<BookmarkModalController>();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/modules/home/widgets/modal/sorting_bottom_modal.dart
+++ b/lib/app/modules/home/widgets/modal/sorting_bottom_modal.dart
@@ -12,10 +12,27 @@ import 'package:flutter/widgets.dart';
 
 import 'package:get/get.dart';
 
-class SortingBottomModal extends StatelessWidget {
+class SortingBottomModal extends StatefulWidget {
   const SortingBottomModal({super.key});
 
+  @override
+  State<SortingBottomModal> createState() => _SortingBottomModalState();
+}
+
+class _SortingBottomModalState extends State<SortingBottomModal> {
   SortingModalController get controller => Get.find<SortingModalController>();
+
+  @override
+  void initState() {
+    Get.put<SortingModalController>(SortingModalController());
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    Get.delete<SortingModalController>();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/modules/home/widgets/modal/sorting_bottom_modal.dart
+++ b/lib/app/modules/home/widgets/modal/sorting_bottom_modal.dart
@@ -60,31 +60,35 @@ class SortingBottomModal extends StatelessWidget {
           ...List<Widget>.generate(types.length, (i) {
             EventSortingType type = types[i];
 
-            return Padding(
-              padding: EdgeInsetsGeometry.symmetric(vertical: 20),
-              child: Row(
-                children: [
-                  Text(
-                    type.displayName,
-                    style: TextStyle(
-                      color: AppColors.black,
-                      fontSize: 15,
-                      fontWeight: FontWeight.w400,
-                      height: 1.20,
+            return Listener(
+              behavior: HitTestBehavior.translucent,
+              onPointerDown: (_) {
+                controller.selectedType = type;
+                HapticFeedback.selectionClick();
+              },
+              child: Padding(
+                padding: EdgeInsetsGeometry.symmetric(vertical: 20),
+                child: Row(
+                  children: [
+                    Text(
+                      type.displayName,
+                      style: TextStyle(
+                        color: AppColors.black,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w400,
+                        height: 1.20,
+                      ),
                     ),
-                  ),
-                  Spacer(),
-                  Obx(() {
-                    var selectedType = controller.selectedType;
-                    return AppRadioButtom(
-                      checked: selectedType == type,
-                      onTap: () {
-                        controller.selectedType = type;
-                        HapticFeedback.selectionClick();
-                      },
-                    );
-                  }),
-                ],
+                    Spacer(),
+                    Obx(() {
+                      var selectedType = controller.selectedType;
+                      return AppRadioButtom(
+                        checked: selectedType == type,
+                        onTap: () {},
+                      );
+                    }),
+                  ],
+                ),
               ),
             );
           }),

--- a/lib/app/modules/notifications/widgets/notification_item.dart
+++ b/lib/app/modules/notifications/widgets/notification_item.dart
@@ -1,4 +1,5 @@
 import 'package:duty_it/app/core/constants/app_colors.dart';
+import 'package:duty_it/app/core/utils/app_utils.dart';
 import 'package:duty_it/app/modules/notifications/controllers/notifications_view_controller.dart';
 import 'package:duty_it/app/modules/notifications/models/app_notification.dart';
 import 'package:duty_it/app/core/models/event.dart';
@@ -43,7 +44,7 @@ class NotificationItem extends StatelessWidget {
         onTap: () async {
           if (noti.event == null) return;
           Event event = noti.event!;
-          if (await canLaunchUrlString(event.uri)) launchUrlString(event.uri);
+          if (await canLaunchUrlString(event.uri)) launchUrlString(AppUtils.setDuitUtmSourceString(event.uri));
         },
         child: Container(
           padding: EdgeInsets.symmetric(vertical: 8, horizontal: 16),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.0+1
+version: 1.3.1+1
 
 environment:
   sdk: ^3.8.0-278.1.beta


### PR DESCRIPTION
# 작업 내용
- Firebase Auth getIdToken 메서드에서 예외 발생시 Firebase Crashlytics에 보고하도록 추가
- modal 위젯이 직접 본인 생명주기에서 컨트롤러를 생성하고 버리도록 수정
- 정렬 옵션 터치박스를 확대하여 UX 개선
- 행사 목록 페이지 조회 이벤트를 FirebaseAnalytics에 로깅하도록 추가
- 행사 주소로 이동시 utm_source 파라미터를 지정하여 해당 사이트에서 듀잇을 인지할 수 있도록 추가
- (iOS) ITSAppUsesNonExemptEncryption 키 값 false로 info.plist에 지정하여 배포 과정에서 발생하는 번거로움 해소