### PR TITLE
deploy(beta): build 74 - 백그라운드 패치 및 종료된 행사 표시 이슈 해결

### DIFF
--- a/.github/workflows/beta_version_check.yml
+++ b/.github/workflows/beta_version_check.yml
@@ -22,13 +22,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin develop:refs/remotes/origin/develop
+          git fetch origin release:refs/remotes/origin/release
           git fetch origin beta:refs/remotes/origin/beta
 
-          develop_ver_full="$(git show origin/develop:pubspec.yaml | awk -F': *' '$1=="version"{print $2; exit}')"
+          release_ver_full="$(git show origin/release:pubspec.yaml | awk -F': *' '$1=="version"{print $2; exit}')"
           beta_ver_full="$(git show origin/beta:pubspec.yaml | awk -F': *' '$1=="version"{print $2; exit}')"
 
-          if [[ "${beta_ver_full}" == "${develop_ver_full}" ]]; then
+          if [[ "${beta_ver_full}" == "${release_ver_full}" ]]; then
             echo "❌ FAIL: 릴리즈 버전과 베타의 버전이 동일합니다."
             exit 1
           fi

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,7 +30,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  use_frameworks! :linkage => :static
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -33,6 +33,14 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+	<string>fetch</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+	<string>com.transistorsoft.fetch</string>
+	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -33,10 +33,6 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIBackgroundModes</key>
-	<array>
-	<string>fetch</string>
-	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 	<string>com.transistorsoft.fetch</string>
@@ -75,7 +71,8 @@
 	<string>348194173787-lbm02t1gmn4krroo8ehjl0c0a7hh1f0m.apps.googleusercontent.com</string>
 	<key>UIBackgroundModes</key>
 	<array>
-	<string>remote-notification</string>
+		<string>fetch</string>
+		<string>remote-notification</string>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>

--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -24,6 +24,11 @@ import 'package:get/get.dart';
 class ApiClient extends GetConnect {
   Future<RequestResult<LoginResult>>? _loginFuture;
   String? _token;
+  bool _background = false;
+
+  ApiClient({bool background = false}) {
+    _background = background;
+  }
 
   @override
   void onInit() {
@@ -32,6 +37,7 @@ class ApiClient extends GetConnect {
     httpClient.baseUrl = dotenv.env['server'];
     httpClient.timeout = const Duration(seconds: 15);
     httpClient.defaultContentType = 'application/json';
+    httpClient.userAgent = buildUserAgent();
 
     httpClient.addRequestModifier<void>((request) async {
       final path = request.url.path;
@@ -61,6 +67,16 @@ class ApiClient extends GetConnect {
     httpClient.maxAuthRetries = 1;
 
     loginAndRefreshToken();
+  }
+
+  String buildUserAgent() {
+    final platform = Platform.isAndroid
+        ? 'android'
+        : Platform.isIOS
+        ? 'ios'
+        : 'unknown';
+
+    return 'Duit-Client/1.0.0 (flutter; $platform${_background ? '; background' : ''}; ${kDebugMode ? 'debug' : 'release'})';
   }
 
   Map<String, String> _cleanQuery(Map<String, dynamic> raw) {
@@ -160,9 +176,9 @@ class ApiClient extends GetConnect {
 
   /// 알람 목록 조회 (alarms)
   Future<RequestResult<List<AppNotification>>> getNotificationList(
-    int page,
-    {int size = 10}
-  ) async {
+    int page, {
+    int size = 10,
+  }) async {
     return await _send(
       () async => await get(
         '/v1/alarms',

--- a/lib/app/api_client.dart
+++ b/lib/app/api_client.dart
@@ -352,11 +352,18 @@ class ApiClient extends GetConnect {
       query += "&searchKeyword=${Uri.encodeQueryComponent(searchKeyword)}";
     }
 
+    return await getEventsByUrl('/v2/events?$query');
+  }
+
+  Future<RequestResult<EventsResponse>> getEventsByUrl(String url) async {
     return _send(
-      () async => await get('/v2/events?$query'),
+      () async => await get(url),
       map: (rp) {
         String bodyString = rp.bodyString!;
-        return EventsResponse.fromJson(json.decode(bodyString));
+        EventsResponse rep = EventsResponse.fromJson(json.decode(bodyString));
+        rep = rep.copyWith(reqUrl: rp.request?.url.toString());
+
+        return rep;
       },
     );
   }

--- a/lib/app/core/models/events_response.dart
+++ b/lib/app/core/models/events_response.dart
@@ -19,6 +19,7 @@ abstract class EventsResponse with _$EventsResponse {
     const factory EventsResponse({
         @JsonKey(name: 'content') required List<Event> events,
         required EventsPageInfo pageInfo,
+        @JsonKey(includeFromJson: false, includeToJson: false) String? reqUrl
     }) = _EventsResponse;
 
     factory EventsResponse.fromJson(Map<String, dynamic> json) => _$EventsResponseFromJson(json);

--- a/lib/app/core/models/events_response.freezed.dart
+++ b/lib/app/core/models/events_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EventsResponse {
 
-@JsonKey(name: 'content') List<Event> get events; EventsPageInfo get pageInfo;
+@JsonKey(name: 'content') List<Event> get events; EventsPageInfo get pageInfo;@JsonKey(includeFromJson: false, includeToJson: false) String? get reqUrl;
 /// Create a copy of EventsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EventsResponseCopyWith<EventsResponse> get copyWith => _$EventsResponseCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventsResponse&&const DeepCollectionEquality().equals(other.events, events)&&(identical(other.pageInfo, pageInfo) || other.pageInfo == pageInfo));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventsResponse&&const DeepCollectionEquality().equals(other.events, events)&&(identical(other.pageInfo, pageInfo) || other.pageInfo == pageInfo)&&(identical(other.reqUrl, reqUrl) || other.reqUrl == reqUrl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(events),pageInfo);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(events),pageInfo,reqUrl);
 
 @override
 String toString() {
-  return 'EventsResponse(events: $events, pageInfo: $pageInfo)';
+  return 'EventsResponse(events: $events, pageInfo: $pageInfo, reqUrl: $reqUrl)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EventsResponseCopyWith<$Res>  {
   factory $EventsResponseCopyWith(EventsResponse value, $Res Function(EventsResponse) _then) = _$EventsResponseCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'content') List<Event> events, EventsPageInfo pageInfo
+@JsonKey(name: 'content') List<Event> events, EventsPageInfo pageInfo,@JsonKey(includeFromJson: false, includeToJson: false) String? reqUrl
 });
 
 
@@ -65,11 +65,12 @@ class _$EventsResponseCopyWithImpl<$Res>
 
 /// Create a copy of EventsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? events = null,Object? pageInfo = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? events = null,Object? pageInfo = null,Object? reqUrl = freezed,}) {
   return _then(_self.copyWith(
 events: null == events ? _self.events : events // ignore: cast_nullable_to_non_nullable
 as List<Event>,pageInfo: null == pageInfo ? _self.pageInfo : pageInfo // ignore: cast_nullable_to_non_nullable
-as EventsPageInfo,
+as EventsPageInfo,reqUrl: freezed == reqUrl ? _self.reqUrl : reqUrl // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 /// Create a copy of EventsResponse
@@ -163,10 +164,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo, @JsonKey(includeFromJson: false, includeToJson: false)  String? reqUrl)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EventsResponse() when $default != null:
-return $default(_that.events,_that.pageInfo);case _:
+return $default(_that.events,_that.pageInfo,_that.reqUrl);case _:
   return orElse();
 
 }
@@ -184,10 +185,10 @@ return $default(_that.events,_that.pageInfo);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo, @JsonKey(includeFromJson: false, includeToJson: false)  String? reqUrl)  $default,) {final _that = this;
 switch (_that) {
 case _EventsResponse():
-return $default(_that.events,_that.pageInfo);case _:
+return $default(_that.events,_that.pageInfo,_that.reqUrl);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -204,10 +205,10 @@ return $default(_that.events,_that.pageInfo);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'content')  List<Event> events,  EventsPageInfo pageInfo, @JsonKey(includeFromJson: false, includeToJson: false)  String? reqUrl)?  $default,) {final _that = this;
 switch (_that) {
 case _EventsResponse() when $default != null:
-return $default(_that.events,_that.pageInfo);case _:
+return $default(_that.events,_that.pageInfo,_that.reqUrl);case _:
   return null;
 
 }
@@ -219,7 +220,7 @@ return $default(_that.events,_that.pageInfo);case _:
 @JsonSerializable()
 
 class _EventsResponse implements EventsResponse {
-  const _EventsResponse({@JsonKey(name: 'content') required final  List<Event> events, required this.pageInfo}): _events = events;
+  const _EventsResponse({@JsonKey(name: 'content') required final  List<Event> events, required this.pageInfo, @JsonKey(includeFromJson: false, includeToJson: false) this.reqUrl}): _events = events;
   factory _EventsResponse.fromJson(Map<String, dynamic> json) => _$EventsResponseFromJson(json);
 
  final  List<Event> _events;
@@ -230,6 +231,7 @@ class _EventsResponse implements EventsResponse {
 }
 
 @override final  EventsPageInfo pageInfo;
+@override@JsonKey(includeFromJson: false, includeToJson: false) final  String? reqUrl;
 
 /// Create a copy of EventsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -244,16 +246,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventsResponse&&const DeepCollectionEquality().equals(other._events, _events)&&(identical(other.pageInfo, pageInfo) || other.pageInfo == pageInfo));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventsResponse&&const DeepCollectionEquality().equals(other._events, _events)&&(identical(other.pageInfo, pageInfo) || other.pageInfo == pageInfo)&&(identical(other.reqUrl, reqUrl) || other.reqUrl == reqUrl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_events),pageInfo);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_events),pageInfo,reqUrl);
 
 @override
 String toString() {
-  return 'EventsResponse(events: $events, pageInfo: $pageInfo)';
+  return 'EventsResponse(events: $events, pageInfo: $pageInfo, reqUrl: $reqUrl)';
 }
 
 
@@ -264,7 +266,7 @@ abstract mixin class _$EventsResponseCopyWith<$Res> implements $EventsResponseCo
   factory _$EventsResponseCopyWith(_EventsResponse value, $Res Function(_EventsResponse) _then) = __$EventsResponseCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'content') List<Event> events, EventsPageInfo pageInfo
+@JsonKey(name: 'content') List<Event> events, EventsPageInfo pageInfo,@JsonKey(includeFromJson: false, includeToJson: false) String? reqUrl
 });
 
 
@@ -281,11 +283,12 @@ class __$EventsResponseCopyWithImpl<$Res>
 
 /// Create a copy of EventsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? events = null,Object? pageInfo = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? events = null,Object? pageInfo = null,Object? reqUrl = freezed,}) {
   return _then(_EventsResponse(
 events: null == events ? _self._events : events // ignore: cast_nullable_to_non_nullable
 as List<Event>,pageInfo: null == pageInfo ? _self.pageInfo : pageInfo // ignore: cast_nullable_to_non_nullable
-as EventsPageInfo,
+as EventsPageInfo,reqUrl: freezed == reqUrl ? _self.reqUrl : reqUrl // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/app/modules/home/cache/home_view_cache.dart
+++ b/lib/app/modules/home/cache/home_view_cache.dart
@@ -3,21 +3,22 @@ import 'package:get_storage/get_storage.dart';
 
 class HomeViewCache {
   static final String boxName = "homeContainer";
-  static final String eventListKey = "event_list";
-  static final String eventsUrlKey = "request_url";
-  static final String eventsLastUpdateCacheKey = "last_update";
+   static const int _cacheValidityInDays = 7;
+  static const String _eventListKey = "event_list";
+  static const String _eventsUrlKey = "request_url";
+  static const String _eventsLastUpdateCacheKey = "last_update";
 
   final GetStorage _box = GetStorage(boxName);
 
   EventsResponse? getEvents() {
-    final Map? listCache = _box.read(eventListKey);
-    final int? lastUpdateMills = _box.read(eventsLastUpdateCacheKey);
+    final Map? listCache = _box.read(_eventListKey);
+    final int? lastUpdateMills = _box.read(_eventsLastUpdateCacheKey);
     final DateTime? lastUpdate = lastUpdateMills != null
         ? DateTime.fromMillisecondsSinceEpoch(lastUpdateMills)
         : null;
     final bool isValid =
         lastUpdate != null &&
-        DateTime.now().difference(lastUpdate).inDays < 7 &&
+        DateTime.now().difference(lastUpdate).inDays < _cacheValidityInDays &&
         listCache != null;
 
     if (!isValid) return null;
@@ -27,16 +28,16 @@ class HomeViewCache {
 
   Future<void> saveEvents(EventsResponse rep) async {
     await Future.wait([
-      _box.write(eventListKey, rep.toJson()),
-      if (rep.reqUrl != null) _box.write(eventsUrlKey, rep.reqUrl),
+      _box.write(_eventListKey, rep.toJson()),
+      if (rep.reqUrl != null) _box.write(_eventsUrlKey, rep.reqUrl),
       _box.write(
-        eventsLastUpdateCacheKey,
+        _eventsLastUpdateCacheKey,
         DateTime.now().millisecondsSinceEpoch,
       ),
     ]);
   }
 
   String? getEventsUrl() {
-    return _box.read(eventsUrlKey);
+    return _box.read(_eventsUrlKey);
   }
 }

--- a/lib/app/modules/home/cache/home_view_cache.dart
+++ b/lib/app/modules/home/cache/home_view_cache.dart
@@ -1,0 +1,42 @@
+import 'package:duty_it/app/core/models/events_response.dart';
+import 'package:get_storage/get_storage.dart';
+
+class HomeViewCache {
+  static final String boxName = "homeContainer";
+  static final String eventListKey = "event_list";
+  static final String eventsUrlKey = "request_url";
+  static final String eventsLastUpdateCacheKey = "last_update";
+
+  final GetStorage _box = GetStorage(boxName);
+
+  EventsResponse? getEvents() {
+    final Map? listCache = _box.read(eventListKey);
+    final int? lastUpdateMills = _box.read(eventsLastUpdateCacheKey);
+    final DateTime? lastUpdate = lastUpdateMills != null
+        ? DateTime.fromMillisecondsSinceEpoch(lastUpdateMills)
+        : null;
+    final bool isValid =
+        lastUpdate != null &&
+        DateTime.now().difference(lastUpdate).inDays < 7 &&
+        listCache != null;
+
+    if (!isValid) return null;
+
+    return EventsResponse.fromJson(Map<String, dynamic>.from(listCache));
+  }
+
+  Future<void> saveEvents(EventsResponse rep) async {
+    await Future.wait([
+      _box.write(eventListKey, rep.toJson()),
+      if (rep.reqUrl != null) _box.write(eventsUrlKey, rep.reqUrl),
+      _box.write(
+        eventsLastUpdateCacheKey,
+        DateTime.now().millisecondsSinceEpoch,
+      ),
+    ]);
+  }
+
+  String? getEventsUrl() {
+    return _box.read(eventsUrlKey);
+  }
+}

--- a/lib/app/modules/home/cache/home_view_cache.dart
+++ b/lib/app/modules/home/cache/home_view_cache.dart
@@ -3,7 +3,7 @@ import 'package:get_storage/get_storage.dart';
 
 class HomeViewCache {
   static final String boxName = "homeContainer";
-   static const int _cacheValidityInDays = 7;
+  static const int _cacheValidityInDays = 7;
   static const String _eventListKey = "event_list";
   static const String _eventsUrlKey = "request_url";
   static const String _eventsLastUpdateCacheKey = "last_update";

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -30,6 +30,10 @@ enum HomeTab { event, bookmark }
 
 class HomeViewController extends GetxController {
   static final String storageBoxName = "homeContainer";
+  static final String listCacheKey = "event_list";
+  static final String urlCacheKey = "request_url";
+  static final String lastUpdateCacheKey = "last_update";
+  
   final FirebaseAnalytics analytics = FirebaseAnalytics.instance;
   final ScrollController scrollController = ScrollController();
 
@@ -170,14 +174,16 @@ class HomeViewController extends GetxController {
     }
 
     GetStorage box = GetStorage(storageBoxName);
-    final String cacheKey = "event_list_cache_key";
+
     if (loadCache) {
       try {
-        Map? cache = box.read(cacheKey);
+        Map? listCache = box.read(listCacheKey);
+        int? lastUpdateMills = box.read(lastUpdateCacheKey);
+        DateTime? lastUpdate = lastUpdateMills != null ? DateTime.fromMillisecondsSinceEpoch(lastUpdateMills) : null;
 
-        if (cache != null) {
+        if (lastUpdate != null && DateTime.now().difference(lastUpdate).inDays < 7 && listCache != null) {
           EventsResponse cachedResponse = EventsResponse.fromJson(
-            Map<String, dynamic>.from(cache),
+            Map<String, dynamic>.from(listCache),
           );
           pagingState = pagingState.copyWith(
             keys: [
@@ -243,7 +249,9 @@ class HomeViewController extends GetxController {
         );
 
         if (clearPage && searchQuery.isEmpty) {
-          box.write(cacheKey, response.toJson());
+          box.write(listCacheKey, response.toJson());
+          box.write(urlCacheKey, response.reqUrl);
+          box.write(lastUpdateCacheKey, DateTime.now().millisecondsSinceEpoch);
         }
       } else {
         var fail = reqResult as RequestFail;

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/core/enums/event_sorting_type.dart';
 import 'package:duty_it/app/core/models/events_response.dart';
+import 'package:duty_it/app/modules/home/cache/home_view_cache.dart';
 import 'package:duty_it/app/modules/notifications/models/app_notification.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:duty_it/app/services/event/events/event_bookmark_event.dart';
@@ -29,11 +30,7 @@ import 'package:synchronized/synchronized.dart';
 enum HomeTab { event, bookmark }
 
 class HomeViewController extends GetxController {
-  static final String cacheStorageBoxName = "homeContainer";
-  static final String listCacheKey = "event_list";
-  static final String urlCacheKey = "request_url";
-  static final String lastUpdateCacheKey = "last_update";
-
+  final HomeViewCache _cache = HomeViewCache();
   final FirebaseAnalytics analytics = FirebaseAnalytics.instance;
   final ScrollController scrollController = ScrollController();
 
@@ -181,22 +178,10 @@ class HomeViewController extends GetxController {
       }
     }
 
-    GetStorage box = GetStorage(cacheStorageBoxName);
-
     if (loadCache) {
       try {
-        Map? listCache = box.read(listCacheKey);
-        int? lastUpdateMills = box.read(lastUpdateCacheKey);
-        DateTime? lastUpdate = lastUpdateMills != null
-            ? DateTime.fromMillisecondsSinceEpoch(lastUpdateMills)
-            : null;
-
-        if (lastUpdate != null &&
-            DateTime.now().difference(lastUpdate).inDays < 7 &&
-            listCache != null) {
-          EventsResponse cachedResponse = EventsResponse.fromJson(
-            Map<String, dynamic>.from(listCache),
-          );
+        var cachedResponse = _cache.getEvents();
+        if (cachedResponse != null) {
           pagingState = pagingState.copyWith(
             keys: [
               ...pagingState.keys ?? [],
@@ -267,9 +252,7 @@ class HomeViewController extends GetxController {
         );
 
         if (clearPage && searchQuery.isEmpty) {
-          box.write(listCacheKey, response.toJson());
-          box.write(urlCacheKey, response.reqUrl);
-          box.write(lastUpdateCacheKey, DateTime.now().millisecondsSinceEpoch);
+          _cache.saveEvents(response);
         }
       } else {
         var fail = reqResult as RequestFail;

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -29,11 +29,11 @@ import 'package:synchronized/synchronized.dart';
 enum HomeTab { event, bookmark }
 
 class HomeViewController extends GetxController {
-  static final String storageBoxName = "homeContainer";
+  static final String cacheStorageBoxName = "homeContainer";
   static final String listCacheKey = "event_list";
   static final String urlCacheKey = "request_url";
   static final String lastUpdateCacheKey = "last_update";
-  
+
   final FirebaseAnalytics analytics = FirebaseAnalytics.instance;
   final ScrollController scrollController = ScrollController();
 
@@ -135,12 +135,21 @@ class HomeViewController extends GetxController {
     );
   }
 
-  Future<void> fetchNextPage({bool clearPage = false, bool loadCache = false}) async {
+  Future<void> fetchNextPage({
+    bool clearPage = false,
+    bool loadCache = false,
+  }) async {
     if (!clearPage && pagingState.isLoading) return;
-    await _pageFetchLock.synchronized(() async => await _fetchNextPage(clearPage: clearPage, loadCache: loadCache));
+    await _pageFetchLock.synchronized(
+      () async =>
+          await _fetchNextPage(clearPage: clearPage, loadCache: loadCache),
+    );
   }
 
-  Future<void> _fetchNextPage({bool clearPage = false, bool loadCache = false}) async {
+  Future<void> _fetchNextPage({
+    bool clearPage = false,
+    bool loadCache = false,
+  }) async {
     SearchFilterService sfService = Get.find<SearchFilterService>();
 
     // Update paging state
@@ -151,7 +160,6 @@ class HomeViewController extends GetxController {
       keys: clearPage ? null : const Omit(),
       pages: clearPage ? null : const Omit(),
     );
-
 
     // set params
     const int size = 5;
@@ -173,15 +181,19 @@ class HomeViewController extends GetxController {
       }
     }
 
-    GetStorage box = GetStorage(storageBoxName);
+    GetStorage box = GetStorage(cacheStorageBoxName);
 
     if (loadCache) {
       try {
         Map? listCache = box.read(listCacheKey);
         int? lastUpdateMills = box.read(lastUpdateCacheKey);
-        DateTime? lastUpdate = lastUpdateMills != null ? DateTime.fromMillisecondsSinceEpoch(lastUpdateMills) : null;
+        DateTime? lastUpdate = lastUpdateMills != null
+            ? DateTime.fromMillisecondsSinceEpoch(lastUpdateMills)
+            : null;
 
-        if (lastUpdate != null && DateTime.now().difference(lastUpdate).inDays < 7 && listCache != null) {
+        if (lastUpdate != null &&
+            DateTime.now().difference(lastUpdate).inDays < 7 &&
+            listCache != null) {
           EventsResponse cachedResponse = EventsResponse.fromJson(
             Map<String, dynamic>.from(listCache),
           );
@@ -206,7 +218,10 @@ class HomeViewController extends GetxController {
     }
 
     // request
-    FirebaseAnalytics.instance.logEvent(name: 'fetch_events_page', parameters: {'clear_page': "$clearPage"});
+    FirebaseAnalytics.instance.logEvent(
+      name: 'fetch_events_page',
+      parameters: {'clear_page': "$clearPage"},
+    );
     try {
       var apiClient = Get.find<ApiClient>();
       var reqResult = await apiClient.getEvents(
@@ -237,7 +252,10 @@ class HomeViewController extends GetxController {
         }
 
         pagingState = pagingState.copyWith(
-          keys: [...(!loadCache ? (pagingState.keys ?? []) : []), pageInfo.nextCursor],
+          keys: [
+            ...(!loadCache ? (pagingState.keys ?? []) : []),
+            pageInfo.nextCursor,
+          ],
           pages: [
             ...(!loadCache ? (pagingState.pages ?? []) : []),
             List<EventCard>.generate(
@@ -295,7 +313,6 @@ class HomeViewController extends GetxController {
     );
 
     if (!event.isBookmarked && !appSettings.dontShowAutoAddModal.value) {
-      
       showModalBottomSheet(
         context: Get.context!,
         isScrollControlled: true,

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -109,6 +109,12 @@ class _EventCardImageSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cardBorderRadius = BorderRadius.circular(8);
+    final bool eventEnded;
+    if (event.endAt != null) {
+      eventEnded = DateUtils.dateOnly(event.endAt!).isBefore(DateUtils.dateOnly(DateTime.now()));
+    } else {
+      eventEnded = DateUtils.dateOnly(event.startAt!).isBefore(DateUtils.dateOnly(DateTime.now()));
+    }
 
     return AspectRatio(
       aspectRatio: 400 / 200,
@@ -144,9 +150,7 @@ class _EventCardImageSection extends StatelessWidget {
             ),
           ),
           Visibility(
-            visible: DateUtils.dateOnly(
-              event.endAt ?? DateTime.now(),
-            ).isBefore(DateUtils.dateOnly(DateTime.now())),
+            visible: eventEnded,
             child: Container(
               decoration: BoxDecoration(
                 color: AppColors.bg,

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -109,7 +109,7 @@ class _EventCardImageSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cardBorderRadius = BorderRadius.circular(8);
-    final bool eventEnded = DateUtils.dateOnly(event.endAt ?? event.startAt).isBefore(DateUtils.dateOnly(DateTime.now()));
+    final bool eventEnded = DateUtils.dateOnly(event.endAt ?? event.startAt ?? DateTime.now()).isBefore(DateUtils.dateOnly(DateTime.now()));
 
     return AspectRatio(
       aspectRatio: 400 / 200,

--- a/lib/app/modules/home/widgets/event_card.dart
+++ b/lib/app/modules/home/widgets/event_card.dart
@@ -109,12 +109,7 @@ class _EventCardImageSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cardBorderRadius = BorderRadius.circular(8);
-    final bool eventEnded;
-    if (event.endAt != null) {
-      eventEnded = DateUtils.dateOnly(event.endAt!).isBefore(DateUtils.dateOnly(DateTime.now()));
-    } else {
-      eventEnded = DateUtils.dateOnly(event.startAt!).isBefore(DateUtils.dateOnly(DateTime.now()));
-    }
+    final bool eventEnded = DateUtils.dateOnly(event.endAt ?? event.startAt).isBefore(DateUtils.dateOnly(DateTime.now()));
 
     return AspectRatio(
       aspectRatio: 400 / 200,

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -4,6 +4,7 @@ import 'package:duty_it/app/widgets/simple_app_bar.dart';
 import 'package:flutter/material.dart';
 
 import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 import '../controllers/settings_view_controller.dart';
 
@@ -76,6 +77,18 @@ class SettingsView extends GetView<SettingsViewController> {
                       onTap: () => Get.to(LicensePage(applicationName: "듀잇")),
                       child: Text(
                         "오픈소스 라이선스",
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          height: 1.60,
+                          color: AppColors.g05,
+                        ),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () => launchUrlString("mailto:contact@dutyit.net"),
+                      child: Text(
+                        "문의 메일 : contact@dutyit.net",
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w600,

--- a/lib/app/modules/splash/controllers/splash_view_controller.dart
+++ b/lib/app/modules/splash/controllers/splash_view_controller.dart
@@ -18,7 +18,7 @@ class SplashViewController extends GetxController {
       GetStorage.init(AppSettingsService.storageBoxName),
       GetStorage.init(AuthService.storageBoxName),
       GetStorage.init(SearchFilterService.storageBoxName),
-      GetStorage.init(HomeViewController.storageBoxName),
+      GetStorage.init(HomeViewController.cacheStorageBoxName),
       GetStorage.init(appInfoBoxName),
       Future.delayed(Duration(seconds: 1)),
     ]);

--- a/lib/app/modules/splash/controllers/splash_view_controller.dart
+++ b/lib/app/modules/splash/controllers/splash_view_controller.dart
@@ -1,3 +1,4 @@
+import 'package:duty_it/app/modules/home/cache/home_view_cache.dart';
 import 'package:duty_it/app/modules/home/controllers/home_view_controller.dart';
 import 'package:duty_it/app/routes/app_pages.dart';
 import 'package:duty_it/app/services/app_settings_service.dart';
@@ -18,7 +19,7 @@ class SplashViewController extends GetxController {
       GetStorage.init(AppSettingsService.storageBoxName),
       GetStorage.init(AuthService.storageBoxName),
       GetStorage.init(SearchFilterService.storageBoxName),
-      GetStorage.init(HomeViewController.cacheStorageBoxName),
+      GetStorage.init(HomeViewCache.boxName),
       GetStorage.init(appInfoBoxName),
       Future.delayed(Duration(seconds: 1)),
     ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:duty_it/app/core/constants/app_colors.dart';
 import 'package:duty_it/app/core/models/events_response.dart';
 import 'package:duty_it/app/modules/home/cache/home_view_cache.dart';
 import 'package:duty_it/app/modules/home/controllers/home_view_controller.dart';
+import 'package:duty_it/app/services/auth/auth_service.dart';
 import 'package:duty_it/firebase_options.dart';
 import 'package:duty_it/gen/fonts.gen.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -143,8 +144,16 @@ Future<void> initPlatformState() async {
 }
 
 Future<void> _backgroundJob() async {
-  await dotenv.load(fileName: ".env");
-  await GetStorage.init(HomeViewCache.boxName);
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await Future.wait([
+    dotenv.load(fileName: ".env"),
+    GetStorage.init(AuthService.storageBoxName),
+    GetStorage.init(HomeViewCache.boxName),
+    _initFirebase()
+  ]);
+
+  Get.lazyPut(() => AuthService());
 
   var cache = HomeViewCache();
   String? cacheUrl = cache.getEventsUrl();
@@ -156,4 +165,5 @@ Future<void> _backgroundJob() async {
 
   EventsResponse rep = (result as RequestSuccess).data;
   await cache.saveEvents(rep);
+  await FirebaseAnalytics.instance.logEvent(name: 'background_fetch_events_updated');
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,8 @@
+import 'package:background_fetch/background_fetch.dart';
+import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/core/constants/app_colors.dart';
+import 'package:duty_it/app/core/models/events_response.dart';
+import 'package:duty_it/app/modules/home/controllers/home_view_controller.dart';
 import 'package:duty_it/firebase_options.dart';
 import 'package:duty_it/gen/fonts.gen.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -10,6 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_auth.dart';
 
 import 'app/routes/app_pages.dart';
@@ -46,6 +51,9 @@ void main() async {
   }
 
   await Future.wait([dotenvFuture]);
+
+  BackgroundFetch.registerHeadlessTask(backgroundFetchHeadlessTask);
+  initPlatformState();
 
   runApp(
     GetMaterialApp(
@@ -90,4 +98,61 @@ Future<void> _initFirebase() async {
   };
 }
 
+@pragma('vm:entry-point')
+void backgroundFetchHeadlessTask(HeadlessTask task) async {
+  String taskId = task.taskId;
+  bool isTimeout = task.timeout;
+  if (isTimeout) {
+    BackgroundFetch.finish(taskId);
+    return;
+  }
 
+  try {
+    await _backgroundJob();
+  } finally {
+    BackgroundFetch.finish(taskId);
+  }
+}
+
+// Configure BackgroundFetch.
+Future<void> initPlatformState() async {
+  await BackgroundFetch.configure(
+    BackgroundFetchConfig(
+      minimumFetchInterval: 15, //TODO: 테스트 후 2시간 이상으로 확대
+      stopOnTerminate: false,
+      enableHeadless: true,
+      requiresBatteryNotLow: true,
+      requiresCharging: false,
+      requiresStorageNotLow: false,
+      requiresDeviceIdle: false,
+      requiredNetworkType: NetworkType.ANY,
+    ),
+    (String taskId) async {
+      try {
+        await _backgroundJob();
+      } finally {
+        BackgroundFetch.finish(taskId);
+      }
+    },
+    (String taskId) async { // Time out handler
+      BackgroundFetch.finish(taskId);
+    },
+  );
+}
+
+Future<void> _backgroundJob() async {
+  await dotenv.load(fileName: ".env");
+  await GetStorage.init(HomeViewController.storageBoxName);
+
+  GetStorage cacheBox = GetStorage(HomeViewController.storageBoxName);
+  String? cacheUrl = cacheBox.read(HomeViewController.urlCacheKey);
+  if (cacheUrl == null) return;
+
+  var client = ApiClient();
+  RequestResult<EventsResponse> result = await client.getEventsByUrl(cacheUrl);
+  if (result is RequestFail) return;
+
+  EventsResponse rep = (result as RequestSuccess).data;
+  await cacheBox.write(HomeViewController.listCacheKey, rep.toJson());
+  await cacheBox.write(HomeViewController.lastUpdateCacheKey, DateTime.now().millisecondsSinceEpoch);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:background_fetch/background_fetch.dart';
 import 'package:duty_it/app/api_client.dart';
 import 'package:duty_it/app/core/constants/app_colors.dart';
 import 'package:duty_it/app/core/models/events_response.dart';
+import 'package:duty_it/app/modules/home/cache/home_view_cache.dart';
 import 'package:duty_it/app/modules/home/controllers/home_view_controller.dart';
 import 'package:duty_it/firebase_options.dart';
 import 'package:duty_it/gen/fonts.gen.dart';
@@ -143,10 +144,10 @@ Future<void> initPlatformState() async {
 
 Future<void> _backgroundJob() async {
   await dotenv.load(fileName: ".env");
-  await GetStorage.init(HomeViewController.cacheStorageBoxName);
+  await GetStorage.init(HomeViewCache.boxName);
 
-  GetStorage cacheBox = GetStorage(HomeViewController.cacheStorageBoxName);
-  String? cacheUrl = cacheBox.read(HomeViewController.urlCacheKey);
+  var cache = HomeViewCache();
+  String? cacheUrl = cache.getEventsUrl();
   if (cacheUrl == null) return;
 
   var client = ApiClient();
@@ -154,9 +155,5 @@ Future<void> _backgroundJob() async {
   if (result is RequestFail) return;
 
   EventsResponse rep = (result as RequestSuccess).data;
-  await cacheBox.write(HomeViewController.listCacheKey, rep.toJson());
-  await cacheBox.write(
-    HomeViewController.lastUpdateCacheKey,
-    DateTime.now().millisecondsSinceEpoch,
-  );
+  await cache.saveEvents(rep);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -134,7 +134,8 @@ Future<void> initPlatformState() async {
         BackgroundFetch.finish(taskId);
       }
     },
-    (String taskId) async { // Time out handler
+    (String taskId) async {
+      // Time out handler
       BackgroundFetch.finish(taskId);
     },
   );
@@ -142,9 +143,9 @@ Future<void> initPlatformState() async {
 
 Future<void> _backgroundJob() async {
   await dotenv.load(fileName: ".env");
-  await GetStorage.init(HomeViewController.storageBoxName);
+  await GetStorage.init(HomeViewController.cacheStorageBoxName);
 
-  GetStorage cacheBox = GetStorage(HomeViewController.storageBoxName);
+  GetStorage cacheBox = GetStorage(HomeViewController.cacheStorageBoxName);
   String? cacheUrl = cacheBox.read(HomeViewController.urlCacheKey);
   if (cacheUrl == null) return;
 
@@ -154,5 +155,8 @@ Future<void> _backgroundJob() async {
 
   EventsResponse rep = (result as RequestSuccess).data;
   await cacheBox.write(HomeViewController.listCacheKey, rep.toJson());
-  await cacheBox.write(HomeViewController.lastUpdateCacheKey, DateTime.now().millisecondsSinceEpoch);
+  await cacheBox.write(
+    HomeViewController.lastUpdateCacheKey,
+    DateTime.now().millisecondsSinceEpoch,
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -159,7 +159,7 @@ Future<void> _backgroundJob() async {
   String? cacheUrl = cache.getEventsUrl();
   if (cacheUrl == null) return;
 
-  var client = ApiClient();
+  var client = ApiClient(background: true);
   RequestResult<EventsResponse> result = await client.getEventsByUrl(cacheUrl);
   if (result is RequestFail) return;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  background_fetch:
+    dependency: "direct main"
+    description:
+      name: background_fetch
+      sha256: "6f0cec85480eac151f3971f883180d8c0acf6b40001153f1cf7c2c453df4f851"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   shared_preferences: ^2.5.3
   scroll_snap_list: ^0.9.1
   cloud_functions: ^6.0.2
+  background_fetch: ^1.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 작업 내용
- 백그라운드에서 행사 목록을 패치합니다. 이는 유저가 다음 실행에 더 빠르게 최신 정보를 확인할 수 있도록 합니다.
- 홈 뷰 캐시를 HomeViewCache에서 관리합니다. 백그라운드 패치 코드와 HomeViewController와의 의존성을 낮추고 HomeViewController에 cache와 관련된 코드를 줄이기 위함입니다.
- 캐시는 7일간 유효합니다.
- EventsResponse에 ``String?`` 타입의 API 요청 주소가 포함되도록 추가되었습니다. HomeViewCache는 ApiClient에서 이 url을 통해 요청을 보냅니다. 유저가 설정한 필터 설정을 유지하면서도 앱 설정 서비스에 의존하지 않기 위한 방법입니다. 추후 서버 api의 스펙이 수정될 경우 필터가 올바르게 적용되지 않은 결과가 표시될 수 있기에 낮은 우선순위로 수정할 계획입니다.
- 종료일이 없는 행사에 대해서 행사 종료 표시가 올바르게 표시되지 않는 문제를 해결하였습니다. 행사 종료일이 없는 경우 행사 시작일을 기준으로 판단합니다.
- ApiClient에 user-agent를 지정하여 서버에서 분석할 수 있도록 합니다.
- 앱 설정 화면에 문의할 수 있는 메일 주소를 추가하였습니다.