### PR TITLE
deploy(beta): build 76 - 행사 북마크시 기기 캘린더 연동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <application
         android:label="듀잇"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -15,6 +15,10 @@
 		<string>듀티</string>
 		<string>간호사</string>
 	</array>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>듀잇에서 북마크한 행사를 캘린더에 추가하고 수정하기 위해 접근이 필요해요.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>듀잇에서 북마크한 행사를 캘린더에 추가하고 수정하기 위해 전체 접근이 필요해요.</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -15,6 +15,8 @@
 		<string>듀티</string>
 		<string>간호사</string>
 	</array>
+	<key>NSCalendarsUsageDescription</key>
+	<string>듀잇에서 북마크한 행사를 캘린더에 추가하고 수정하기 위해 접근이 필요해요.</string>
 	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
 	<string>듀잇에서 북마크한 행사를 캘린더에 추가하고 수정하기 위해 접근이 필요해요.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>

--- a/lib/app/modules/home/controllers/bookmark_modal_controller.dart
+++ b/lib/app/modules/home/controllers/bookmark_modal_controller.dart
@@ -22,7 +22,6 @@ class BookmarkModalController extends GetxController {
   }
 
   Future<void> done(bool addToCal) async {
-    Get.back();
     var api = Get.find<ApiClient>();
     var user = Get.find<AuthService>().appUser!;
 
@@ -43,5 +42,7 @@ class BookmarkModalController extends GetxController {
     eventRx.value = event.copyWith(
       isBookmarked: await hController.toggleBookmark(event),
     );
+
+    Get.back();
   }
 }

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -253,7 +253,7 @@ class HomeViewController extends GetxController {
           hasNextPage: hasNext,
         );
 
-        if (clearPage && searchQuery.isEmpty) {
+        if (clearPage && searchQuery.isEmpty && _selectedTab.value == HomeTab.event) {
           _cache.saveEvents(response);
         }
       } else {

--- a/lib/app/modules/home/controllers/home_view_controller.dart
+++ b/lib/app/modules/home/controllers/home_view_controller.dart
@@ -14,6 +14,7 @@ import 'package:duty_it/app/modules/notifications/models/app_notification.dart';
 import 'package:duty_it/app/routes/app_pages.dart';
 import 'package:duty_it/app/services/app_settings_service.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
+import 'package:duty_it/app/services/calendar_service.dart';
 import 'package:duty_it/app/services/event/app_event_service.dart';
 import 'package:duty_it/app/services/event/events/event_bookmark_event.dart';
 import 'package:duty_it/app/services/search_filter/search_filter_service.dart';
@@ -253,7 +254,9 @@ class HomeViewController extends GetxController {
           hasNextPage: hasNext,
         );
 
-        if (clearPage && searchQuery.isEmpty && _selectedTab.value == HomeTab.event) {
+        if (clearPage &&
+            searchQuery.isEmpty &&
+            _selectedTab.value == HomeTab.event) {
           _cache.saveEvents(response);
         }
       } else {
@@ -311,7 +314,7 @@ class HomeViewController extends GetxController {
     );
 
     if (!event.isBookmarked && !appSettings.dontShowAutoAddModal.value) {
-      showModalBottomSheet(
+      await showModalBottomSheet(
         context: Get.context!,
         isScrollControlled: true,
         shape: RoundedRectangleBorder(
@@ -323,6 +326,32 @@ class HomeViewController extends GetxController {
       eventRx.value = event.copyWith(isBookmarked: !event.isBookmarked);
 
       eventRx.value = event.copyWith(isBookmarked: await toggleBookmark(event));
+    }
+
+    var user = Get.find<AuthService>().appUser!;
+    var calendarService = Get.find<CalendarService>();
+    if (eventRx.value.isBookmarked && user.autoAddBookmarkToCalendar) {
+      var result = await calendarService.requestPermission();
+      if (!result) {
+        AppUtils.showSnackBar("캘린더 접근 권한이 없어요.");
+        return;
+      }
+
+      DateTime now = DateTime.now();
+      DateTime start = event.startAt ?? now;
+      DateTime end = event.endAt ?? start;
+
+      await Get.find<CalendarService>().addEvent(
+        title: event.title,
+        startDate: start,
+        endDate: end,
+        id: event.id.toString(), 
+        description: "${event.host.name}\n${event.uri}",
+      );
+    } else if (!eventRx.value.isBookmarked) {
+      if (await calendarService.checkPermission()) {
+        await calendarService.removeEvent(event.id.toString());
+      }
     }
   }
 

--- a/lib/app/modules/main/bindings/main_binding.dart
+++ b/lib/app/modules/main/bindings/main_binding.dart
@@ -1,5 +1,6 @@
 import 'package:duty_it/app/modules/calendar/controllers/calendar_view_controller.dart';
 import 'package:duty_it/app/modules/home/controllers/home_view_controller.dart';
+import 'package:duty_it/app/services/calendar_service.dart';
 import 'package:duty_it/app/services/event/app_event_service.dart';
 import 'package:duty_it/app/services/app_settings_service.dart';
 import 'package:duty_it/app/services/in_app_review_service.dart';
@@ -18,5 +19,6 @@ class MainBinding extends Bindings {
     Get.put<AppSettingsService>(AppSettingsService());
     Get.put<HomeViewController>(HomeViewController());
     Get.put<CalendarViewController>(CalendarViewController());
+    Get.lazyPut(() => CalendarService());
   }
 }

--- a/lib/app/modules/notifications/widgets/notification_item.dart
+++ b/lib/app/modules/notifications/widgets/notification_item.dart
@@ -125,7 +125,7 @@ class NotificationItem extends StatelessWidget {
 
   static String _formatDateTime(DateTime? dt) {
     if (dt == null) return "";
-    return '${dt.year}. ${dt.month.toString().padLeft(2, '0')}. ${dt.day.toString().padLeft(2, '0')} ${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+    return '${dt.year}.${dt.month.toString().padLeft(2, '0')}.${dt.day.toString().padLeft(2, '0')} ${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
   }
 
   static String _getTitle(AppNotification noti) {

--- a/lib/app/modules/search_filter/controllers/host_selection_controller.dart
+++ b/lib/app/modules/search_filter/controllers/host_selection_controller.dart
@@ -30,7 +30,7 @@ class HostSelectionController extends GetxController {
   }
 
   Future<void> _fetchHosts() async {
-    RequestResult<List<Host>> reqResult = await Get.find<ApiClient>().getHosts();
+    RequestResult<List<Host>> reqResult = await Get.find<ApiClient>().getHosts(size: 500);
     if (reqResult is RequestFail) {
       var fail = reqResult.serverFail;
       AppUtils.showSnackBar('주최 목록을 불러오지 못했어요.\n${fail?.message ?? ''}');

--- a/lib/app/modules/search_filter/widgets/host_selection_bottom_modal.dart
+++ b/lib/app/modules/search_filter/widgets/host_selection_bottom_modal.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:duty_it/app/core/constants/app_colors.dart';
 import 'package:duty_it/app/core/models/host.dart';
 import 'package:duty_it/app/modules/search_filter/controllers/host_selection_controller.dart';
@@ -204,6 +205,23 @@ class _HostItem extends StatelessWidget {
                     color: const Color(0xFFD0D0D0),
                   ),
                 ),
+              ),
+              child: CachedNetworkImage(
+                imageUrl: host.thumbnail,
+                imageBuilder: (context, imageProvider) => Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xffD9D9D9),
+                    image: DecorationImage(
+                      image: imageProvider,
+                      fit: BoxFit.fitWidth,
+                      alignment: Alignment.center,
+                    ),
+                  ),
+                ),
+                progressIndicatorBuilder: (_, __, ___) =>
+                    Center(child: Image.asset(Assets.icons.nurseCap.path)),
+                errorWidget: (_, __, ___) =>
+                    Center(child: Image.asset(Assets.icons.nurseCap.path)),
               ),
             ),
             SizedBox(width: 16),

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -66,7 +66,7 @@ class SettingsView extends GetView<SettingsViewController> {
                       () => ToggleSettingItem(
                         title: '북마크 - 캘린더 자동 연동',
                         checked: controller.calendarAutoAdd,
-                        subtitle: "북마크 설정시, 행사 일정을 듀잇 캘린더에 자동으로 등록합니다. ",
+                        subtitle: "북마크 설정시, 모집과 행사 일정을 캘린더에 자동으로 등록합니다. ",
                         onToggleTap: () async =>
                             await controller.toggleAutoAdd(),
                       ),

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -66,7 +66,7 @@ class SettingsView extends GetView<SettingsViewController> {
                       () => ToggleSettingItem(
                         title: '북마크 - 캘린더 자동 연동',
                         checked: controller.calendarAutoAdd,
-                        subtitle: "북마크 설정시, 모집과 행사 일정을 캘린더에 자동으로 등록합니다. ",
+                        subtitle: "북마크 설정시, 행사 일정을 듀잇 캘린더에 자동으로 등록합니다. ",
                         onToggleTap: () async =>
                             await controller.toggleAutoAdd(),
                       ),

--- a/lib/app/modules/settings/views/settings_view.dart
+++ b/lib/app/modules/settings/views/settings_view.dart
@@ -62,7 +62,6 @@ class SettingsView extends GetView<SettingsViewController> {
                     //     enabled: controller.pushNoti,
                     //   ),
                     // ),
-                    SizedBox(height: 40),
                     Obx(
                       () => ToggleSettingItem(
                         title: '북마크 - 캘린더 자동 연동',
@@ -72,7 +71,6 @@ class SettingsView extends GetView<SettingsViewController> {
                             await controller.toggleAutoAdd(),
                       ),
                     ),
-                    SizedBox(height: 40),
                     GestureDetector(
                       onTap: () => Get.to(LicensePage(applicationName: "듀잇")),
                       child: Text(

--- a/lib/app/modules/splash/controllers/splash_view_controller.dart
+++ b/lib/app/modules/splash/controllers/splash_view_controller.dart
@@ -2,6 +2,7 @@ import 'package:duty_it/app/modules/home/cache/home_view_cache.dart';
 import 'package:duty_it/app/routes/app_pages.dart';
 import 'package:duty_it/app/services/app_settings_service.dart';
 import 'package:duty_it/app/services/auth/auth_service.dart';
+import 'package:duty_it/app/services/calendar_service.dart';
 import 'package:duty_it/app/services/search_filter/search_filter_service.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
@@ -20,6 +21,7 @@ class SplashViewController extends GetxController {
       GetStorage.init(SearchFilterService.storageBoxName),
       GetStorage.init(HomeViewCache.boxName),
       GetStorage.init(appInfoBoxName),
+      GetStorage.init(CalendarService.registeredEventsBoxName),
       Future.delayed(Duration(seconds: 1)),
     ]);
     PackageInfo packageInfo = results[0];

--- a/lib/app/services/calendar_service.dart
+++ b/lib/app/services/calendar_service.dart
@@ -32,13 +32,13 @@ class CalendarService extends GetxService {
       }
       return true;
     }
-    var status = await _plugin.hasPermissions();
 
-    if (! await checkPermission()) {
-      await _plugin.requestPermissions();
+    bool hasPermission = await checkPermission();
+    if (!hasPermission) {
+      hasPermission = await _plugin.requestPermissions() == CalendarPermissionStatus.granted;
     }
 
-    return await checkPermission();
+    return hasPermission;
   }
 
   Future<void> addEvent({
@@ -114,14 +114,14 @@ class CalendarService extends GetxService {
   }
 
   Future<void> _registerEvent(String id, String eventId) async {
-    await _box.write(id.toString(), eventId);
+    await _box.write(id, eventId);
   }
   
   Future<void> _unregisterEvent(String id) async {
-    await _box.remove(id.toString());
+    await _box.remove(id);
   }
 
   String? _getRegisteredEventId(String id) {
-    return _box.read(id.toString());
+    return _box.read(id);
   }
 }

--- a/lib/app/services/calendar_service.dart
+++ b/lib/app/services/calendar_service.dart
@@ -1,0 +1,127 @@
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
+
+class CalendarService extends GetxService {
+  static const String registeredEventsBoxName = "calendarServiceRegisteredEvents";
+  late GetStorage _box;
+  final _plugin = DeviceCalendar.instance;
+
+  @override
+  void onReady() {
+    super.onReady();
+    _box = GetStorage(registeredEventsBoxName);
+  }
+
+  Future<bool> checkPermission() async {
+    if (kIsWeb) {
+      if (kDebugMode) {
+        print("웹에서는 캘린더 권한 체크를 건너뜁니다.");
+      }
+      return true;
+    }
+    var status = await _plugin.hasPermissions();
+    return status == CalendarPermissionStatus.granted;
+  }
+
+  Future<bool> requestPermission() async {
+    if (kIsWeb) {
+      if (kDebugMode) {
+        print("웹에서는 캘린더 권한 요청을 건너뜁니다.");
+      }
+      return true;
+    }
+    var status = await _plugin.hasPermissions();
+
+    if (! await checkPermission()) {
+      await _plugin.requestPermissions();
+    }
+
+    return await checkPermission();
+  }
+
+  Future<void> addEvent({
+    required String title,
+    required DateTime startDate,
+    required DateTime endDate,
+    required String id,
+    String? description,
+  }) async {
+    if (kIsWeb) {
+      if (kDebugMode) {
+        print("웹에서는 캘린더 행사 추가 요청을 건너뜁니다.");
+      }
+      return;
+    }
+
+    if (_isRegistered(id)) return;
+
+    String eventId = await _plugin.createEvent(
+      calendarId: (await _getCalendar()).id,
+      title: title,
+      startDate: startDate,
+      endDate: endDate,
+      description: description,
+      timeZone: 'Asia/Seoul',
+      availability: EventAvailability.busy,
+    );
+
+    await _registerEvent(id, eventId);
+
+    await _plugin.showEventModal(eventId);
+  }
+
+  Future<void> removeEvent(String id) async {
+    if (kIsWeb) {
+      if (kDebugMode) {
+        print("웹에서는 캘린더 행사 삭제 요청을 건너뜁니다.");
+      }
+      return;
+    }
+
+    if (!_isRegistered(id)) return;
+
+    String? eventId = _getRegisteredEventId(id);
+    if (eventId != null) {
+      await removeEventByEventId(eventId);
+    }
+
+    await _unregisterEvent(id);
+  }
+
+  Future<void> removeEventByEventId(String eventId) async {
+    if (kIsWeb) {
+      if (kDebugMode) {
+        print("웹에서는 캘린더 행사 삭제 요청을 건너뜁니다.");
+      }
+      return;
+    }
+
+    await _plugin.deleteEvent(eventId: eventId);
+  }
+
+  Future<Calendar> _getCalendar() async {
+    final calendars = await _plugin.listCalendars();
+    return calendars.firstWhere(
+      (cal) => cal.isPrimary && !cal.readOnly,
+      orElse: () => calendars.first,
+    );
+  }
+
+  bool _isRegistered(String id) {
+    return _box.read(id) != null;
+  }
+
+  Future<void> _registerEvent(String id, String eventId) async {
+    await _box.write(id.toString(), eventId);
+  }
+  
+  Future<void> _unregisterEvent(String id) async {
+    await _box.remove(id.toString());
+  }
+
+  String? _getRegisteredEventId(String id) {
+    return _box.read(id.toString());
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.3"
+  device_calendar_plus:
+    dependency: "direct main"
+    description:
+      name: device_calendar_plus
+      sha256: d11a70d98eb123e8eb09fdcfaf220ca4f1aa65a1512e12092f176f4b54983507
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
+  device_calendar_plus_android:
+    dependency: transitive
+    description:
+      name: device_calendar_plus_android
+      sha256: a341ef29fa0251251287d63c1d009dfd35c1459dc6a129fd5e03f5ac92d8d7ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
+  device_calendar_plus_ios:
+    dependency: transitive
+    description:
+      name: device_calendar_plus_ios
+      sha256: "3b2f84ce1ed002be8460e214a3229e66748bbaad4077603f2c734d67c42033ff"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
+  device_calendar_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_calendar_plus_platform_interface
+      sha256: "0ce7511c094ca256831a48e16efe8f1e97e7bd00a5ff3936296ffd650a1d76b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   shared_preferences: ^2.5.3
   scroll_snap_list: ^0.9.1
   background_fetch: ^1.5.0
+  device_calendar_plus: ^0.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 주요 작업
- 주최가 이제 최대 500개까지 표시되며, 섬네일이 표시됩니다.
- 캘린더 자동 연동 기능이 켜져 있는 경우, 행사 북마크시 기기 캘린더에도 행사 정보를 추가합니다.