### PR TITLE
DUIT-25 feat: 딥링크를 통한 이벤트 방문 시 애널리틱스 이벤트 로깅 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,6 +98,10 @@ void _handleUri(Uri uri) {
     final id = uri.pathSegments.length > 1 ? uri.pathSegments[1] : null;
     if (id != null) {
       launchUrl(uri);
+
+      FirebaseAnalytics.instance.logEvent(name: 'deep_link_visitEvent', parameters: {
+        'id': id,
+      });
       return;
     }
   }


### PR DESCRIPTION
딥링크를 통해 이벤트에 방문할 경우, `deep_link_visitEvent`라는 이름의 Firebase Analytics 이벤트를 기록하도록 변경합니다. 이벤트 파라미터로는 이벤트의 `id`가 포함됩니다.