### PR TITLE
DUIT-23 feat: 앱링크 초기 실행시 중복 실행 방지

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,14 +53,7 @@ void main() async {
   }
 
   /* App Links & Universal Links */
-  final appLinks = AppLinks();
-  appLinks.getInitialLink().then((uri) {
-    if (uri != null) _handleUri(uri);
-  });
-
-  appLinks.uriLinkStream.listen((uri) {
-    _handleUri(uri);
-  });
+  _initDeepLinks();
 
   runApp(
     GetMaterialApp(
@@ -90,6 +83,32 @@ void main() async {
       ],
     ),
   );
+}
+
+Future<void> _initDeepLinks() async {
+  final appLinks = AppLinks();
+
+  final initial = await appLinks.getInitialLink();
+  final initialStr = initial?.toString();
+  if (initial != null) _handleUri(initial);
+
+  final DateTime initTime = DateTime.now();
+  bool skipped = false;
+
+  appLinks.uriLinkStream.listen((uri) {
+    final s = uri.toString();
+
+    // Dedupe
+    if (initialStr != null &&
+        initialStr == s &&
+        !skipped &&
+        DateTime.now().difference(initTime) < const Duration(seconds: 5)) {
+      skipped = true;
+      return;
+    }
+
+    _handleUri(uri);
+  });
 }
 
 void _handleUri(Uri uri) {


### PR DESCRIPTION
앱 실행 시 딥링크가 짧은 시간 내에 중복으로 호출되는 문제를 해결합니다.

`getInitialLink()`와 `uriLinkStream`에서 동일한 URI가 5초 이내에 연속으로 수신될 경우, 스트림에서 오는 호출은 무시하도록 중복 제거 로직을 추가했습니다. 또한 관련 코드를 `_initDeepLinks` 함수로 분리하여 코드 구조를 개선했습니다.